### PR TITLE
Settings and home view

### DIFF
--- a/gitlens/gitlens-home.md
+++ b/gitlens/gitlens-home.md
@@ -106,8 +106,6 @@ Launchpad provides a centralized view of your pull requests. You can:
 
 
 ### Worktrees
-
-### Worktrees
 <div class='callout callout--warning'>
     <p>The Community plan supports only public and local repositories.</p>
 </div>

--- a/gitlens/gitlens-settings.md
+++ b/gitlens/gitlens-settings.md
@@ -1,19 +1,27 @@
 ---
-
-title: Settings
-description: GitLens Settings
+title: GitLens Settings Overview
+description: Learn how to access and customize GitLens settings in Visual Studio Code
 taxonomy:
     category: gitlens
-
 ---
+<kbd>Last updated: July 2025</kbd>
 
-<img src="/wp-content/uploads/settings.png" class="help-center-img img-bordered">
+## Overview
 
-GitLens provides a rich **interactive settings editor**, an easy-to-use interface, to configure many of GitLens' powerful features. It can be accessed via the _GitLens: Open Settings_ (`gitlens.showSettingsPage`) command from the [_Command Palette_](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette).
+<figure>
+  <img src="/wp-content/uploads/settings.png" alt="GitLens settings editor UI in Visual Studio Code" class="help-center-img img-bordered">
+  <figcaption style="text-align:center; color:#888">GitLens interactive settings editor in VS Code</figcaption>
+</figure>
 
-GitLens is highly customizable and provides many configuration settings to allow the personalization of almost all features.
+GitLens offers a powerful and easy-to-use **interactive settings editor** that helps you configure many features directly in Visual Studio Code.
 
-##Current Line Blame Settings
+To open the editor, run the _GitLens: Open Settings_ command (`gitlens.showSettingsPage`) from the [Command Palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette).
+
+GitLens is highly customizable—nearly every feature can be tailored to fit your workflow using the available settings.
+
+## Current Line Blame Settings
+
+Use these settings to customize how GitLens displays blame annotations for the current line of code. These annotations help identify the last commit that modified a line, along with contextual details like date, author, and related pull requests.
 
 <table>
 <thead>
@@ -25,50 +33,52 @@ GitLens is highly customizable and provides many configuration settings to allow
 <tbody>
 <tr>
 <td><code>gitlens.currentLine.dateFormat</code></td>
-<td>Specifies how to format absolute dates (e.g. using the <code>${date}</code> token) for the current line blame annotations. See the <a href="https://momentjs.com/docs/#/displaying/format/" rel="nofollow">Moment.js docs</a> for valid formats</td>
+<td>Defines how absolute dates appear in current line blame annotations using the <code>${date}</code> token. Refer to the <a href="https://momentjs.com/docs/#/displaying/format/" rel="nofollow">Moment.js format guide</a>.</td>
 </tr>
 <tr>
 <td><code>gitlens.currentLine.enabled</code></td>
-<td>Specifies whether to provide a blame annotation for the current line, by default. Use the <em>Toggle Line Blame Annotations</em> command (<code>gitlens.toggleLineBlame</code>) to toggle the annotations on and off for the current window</td>
+<td>Enables or disables current line blame annotations by default. Toggle annotations in any window with the <em>Toggle Line Blame Annotations</em> command (<code>gitlens.toggleLineBlame</code>).</td>
 </tr>
 <tr>
 <td><code>gitlens.currentLine.format</code></td>
-<td>Specifies the format of the current line blame annotation. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a> in the GitLens docs. Date formatting is controlled by the <code>gitlens.currentLine.dateFormat</code> setting</td>
+<td>Sets the display format for the annotation. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a> for supported placeholders. Date format is managed by <code>gitlens.currentLine.dateFormat</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.currentLine.pullRequests.enabled</code></td>
-<td>Specifies whether to provide information about the Pull Request (if any) that introduced the commit in the current line blame annotation. Requires a connection to a supported remote service (e.g. GitHub)</td>
+<td>Shows pull request info (if available) for the commit in the current line annotation. Requires a connected remote provider like GitHub.</td>
 </tr>
 <tr>
 <td><code>gitlens.currentLine.scrollable</code></td>
-<td>Specifies whether the current line blame annotation can be scrolled into view when it is outside the viewport. <strong>NOTE</strong>: Setting this to <code>false</code> will inhibit the hovers from showing over the annotation; Set <code>gitlens.hovers.currentLine.over</code> to <code>line</code> to enable the hovers to show anywhere over the line.</td>
+<td>Determines if annotations can scroll into view when off-screen. <strong>Note:</strong> Setting this to <code>false</code> disables hover tooltips unless <code>gitlens.hovers.currentLine.over</code> is set to <code>line</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.currentLine.uncommittedChangesFormat</code></td>
-<td>Specifies the uncommitted changes format of the current line blame annotation. <strong>NOTE</strong>: Setting this to an empty string will disable current line blame annotations for uncommitted changes</td>
+<td>Customizes annotation format for uncommitted changes. An empty string disables annotations for these changes.</td>
 </tr>
 <tr>
 <td><code>gitlens.currentLine.fontFamily</code></td>
-<td>Specifies the font family of the Inline Blame annotation</td>
+<td>Sets the font family for inline blame annotations.</td>
 </tr>
 <tr>
 <td><code>gitlens.currentLine.fontSize</code></td>
-<td>Specifies the font size of the Inline Blame annotation</td>
+<td>Sets the font size for inline blame annotations.</td>
 </tr>
 <tr>
 <td><code>gitlens.currentLine.fontStyle</code></td>
-<td>Specifies the font style of the Inline Blame annotation</td>
+<td>Sets the font style for inline blame annotations.</td>
 </tr>
 <tr>
 <td><code>gitlens.currentLine.fontWeight</code></td>
-<td>Specifies the font weight of the Inline Blame annotation</td>
+<td>Sets the font weight for inline blame annotations.</td>
 </tr>
 </tbody>
 </table>
 
 ***
 
-##Git CodeLens Settings
+## Git CodeLens Settings
+
+These settings control GitLens CodeLens overlays, which provide inline contextual information such as author and commit history directly in your code.
 
 <table>
 <thead>
@@ -80,42 +90,48 @@ GitLens is highly customizable and provides many configuration settings to allow
 <tbody>
 <tr>
 <td><code>gitlens.codeLens.authors.command</code></td>
-<td>Specifies the command to be executed when an <em>authors</em> CodeLens is clicked, set to (<code>gitlens.toggleFileBlame</code>) by default. Can be set to <code>false</code> to disable click actions on the CodeLens.<br><br><code>gitlens.toggleFileBlame</code> - toggles file blame annotations<br><code>gitlens.toggleFileHeatmap</code> - toggles file heatmap<br><code>gitlens.toggleFileChanges</code> - toggles file changes since before the commit<br><code>gitlens.toggleFileChangesOnly</code> - toggles file changes from the commit<br><code>gitlens.diffWithPrevious</code> - opens changes with the previous revision<br><code>gitlens.revealCommitInView</code> - reveals the commit in the Side Bar<br><code>gitlens.showCommitsInView</code> - searches for commits within the range<br><code>gitlens.showQuickCommitDetails</code> - shows details of the commit<br><code>gitlens.showQuickCommitFileDetails</code> - show file details of the commit<br><code>gitlens.showQuickFileHistory</code> - shows the current file history<br><code>gitlens.showQuickRepoHistory</code> - shows the current branch history<br><code>gitlens.openCommitOnRemote</code> - opens the commit on the remote service (when available)<br><code>gitlens.copyRemoteCommitUrl</code> - copies the remote commit url to the clipboard (when available)<br><code>gitlens.openFileOnRemote</code> - opens the file revision on the remote service (when available)<br><code>gitlens.copyRemoteFileUrl</code> - copies the remote file url to the clipboard (when available)</td>
+<td>Sets the command triggered when an <em>authors</em> CodeLens is clicked. Default is <code>gitlens.toggleFileBlame</code>. To disable click actions, set this to <code>false</code>.<br><br>Available commands include:<br>
+<code>gitlens.toggleFileBlame</code>, <code>gitlens.toggleFileHeatmap</code>, <code>gitlens.toggleFileChanges</code>, <code>gitlens.toggleFileChangesOnly</code>, <code>gitlens.diffWithPrevious</code>, <code>gitlens.revealCommitInView</code>, <code>gitlens.showCommitsInView</code>, <code>gitlens.showQuickCommitDetails</code>, <code>gitlens.showQuickCommitFileDetails</code>, <code>gitlens.showQuickFileHistory</code>, <code>gitlens.showQuickRepoHistory</code>, <code>gitlens.openCommitOnRemote</code>, <code>gitlens.copyRemoteCommitUrl</code>, <code>gitlens.openFileOnRemote</code>, <code>gitlens.copyRemoteFileUrl</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.codeLens.authors.enabled</code></td>
-<td>Specifies whether to provide an <em>authors</em> CodeLens, showing number of authors of the file or code block and the most prominent author (if there is more than one)</td>
+<td>Enables or disables the <em>authors</em> CodeLens. Displays the number of contributors and highlights the most active author for a file or block.</td>
 </tr>
 <tr>
 <td><code>gitlens.codeLens.enabled</code></td>
-<td>Specifies whether to provide any Git CodeLens, by default. Use the <em>Toggle Git CodeLens</em> command (<code>gitlens.toggleCodeLens</code>) to toggle the Git CodeLens on and off for the current window</td>
+<td>Globally enables or disables all GitLens CodeLens features. Use the <em>Toggle Git CodeLens</em> command (<code>gitlens.toggleCodeLens</code>) to turn this feature on or off for the current window.</td>
 </tr>
 <tr>
 <td><code>gitlens.codeLens.includeSingleLineSymbols</code></td>
-<td>Specifies whether to provide any Git CodeLens on symbols that span only a single line</td>
+<td>Determines whether GitLens shows CodeLens for single-line symbols (e.g., one-line functions).</td>
 </tr>
 <tr>
 <td><code>gitlens.codeLens.recentChange.command</code></td>
-<td>Specifies the command to be executed when a <em>recent change</em> CodeLens is clicked, set to (<code>gitlens.showQuickCommitFileDetails</code>) by default. Can be set to <code>false</code> to disable click actions on the CodeLens.<br><br><code>gitlens.toggleFileBlame</code> - toggles file blame annotations<br><code>gitlens.toggleFileHeatmap</code> - toggles file heatmap<br><code>gitlens.toggleFileChanges</code> - toggles file changes since before the commit<br><code>gitlens.toggleFileChangesOnly</code> - toggles file changes from the commit<br><code>gitlens.diffWithPrevious</code> - opens changes with the previous revision<br><code>gitlens.revealCommitInView</code> - reveals the commit in the Side Bar<br><code>gitlens.showCommitsInView</code> - searches for commits within the range<br><code>gitlens.showQuickCommitDetails</code> - shows details of the commit<br><code>gitlens.showQuickCommitFileDetails</code> - show file details of the commit<br><code>gitlens.showQuickFileHistory</code> - shows the current file history<br><code>gitlens.showQuickRepoHistory</code> - shows the current branch history<br><code>gitlens.openCommitOnRemote</code> - opens the commit on the remote service (when available)<br><code>gitlens.copyRemoteCommitUrl</code> - copies the remote commit url to the clipboard (when available)<br><code>gitlens.openFileOnRemote</code> - opens the file revision on the remote service (when available)<br><code>gitlens.copyRemoteFileUrl</code> - copies the remote file url to the clipboard (when available)</td>
+<td>Sets the command triggered when a <em>recent change</em> CodeLens is clicked. Default is <code>gitlens.showQuickCommitFileDetails</code>. To disable, set to <code>false</code>.<br><br>Available commands mirror those listed under <code>authors.command</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.codeLens.recentChange.enabled</code></td>
-<td>Specifies whether to provide a <em>recent change</em> CodeLens, showing the author and date of the most recent commit for the file or code block</td>
+<td>Enables or disables the <em>recent change</em> CodeLens. Displays the author and timestamp of the most recent commit for the line or block.</td>
 </tr>
 <tr>
 <td><code>gitlens.codeLens.scopes</code></td>
-<td>Specifies where Git CodeLens will be shown in the document<br><br><code>document</code> - adds CodeLens at the top of the document<br><code>containers</code> - adds CodeLens at the start of container-like symbols (modules, classes, interfaces, etc)<br><code>blocks</code> - adds CodeLens at the start of block-like symbols (functions, methods, etc) lines</td>
+<td>Controls where Git CodeLens is displayed:<br>
+<code>document</code> – top of the file<br>
+<code>containers</code> – start of container symbols (e.g., classes, interfaces)<br>
+<code>blocks</code> – start of block symbols (e.g., functions, methods)</td>
 </tr>
 <tr>
 <td><code>gitlens.codeLens.symbolScopes</code></td>
-<td>Specifies a set of document symbols where Git CodeLens will or will not be shown in the document. Prefix with <code>!</code> to avoid providing a Git CodeLens for the symbol. Must be a member of <a href="https://code.visualstudio.com/docs/extensionAPI/vscode-api#_a-namesymbolkindaspan-classcodeitem-id660symbolkindspan" rel="nofollow"><code>SymbolKind</code></a></td>
+<td>Defines specific symbol types to include or exclude from CodeLens. Prefix a symbol with <code>!</code> to exclude it. Uses <a href="https://code.visualstudio.com/docs/extensionAPI/vscode-api#_a-namesymbolkindaspan-classcodeitem-id660symbolkindspan" rel="nofollow"><code>SymbolKind</code></a> values.</td>
 </tr>
 </tbody>
 </table>
 
 ***
 
-##Status Bar Settings
+## Status Bar Settings
+
+These settings control how GitLens displays blame information in the status bar, including format, alignment, and click behavior.
 
 <table>
 <thead>
@@ -127,41 +143,45 @@ GitLens is highly customizable and provides many configuration settings to allow
 <tbody>
 <tr>
 <td><code>gitlens.statusBar.alignment</code></td>
-<td>Specifies the blame alignment in the status bar<br><br><code>left</code> - aligns to the left<br><code>right</code> - aligns to the right</td>
+<td>Controls where the blame annotation appears in the status bar.<br><br><code>left</code> – aligns to the left<br><code>right</code> – aligns to the right</td>
 </tr>
 <tr>
 <td><code>gitlens.statusBar.command</code></td>
-<td>Specifies the command to be executed when the blame status bar item is clicked<br><br><code>gitlens.toggleFileBlame</code> - toggles file blame annotations<br><code>gitlens.toggleFileHeatmap</code> - toggles file heatmap<br><code>gitlens.toggleFileChanges</code> - toggles file changes since before the commit<br><code>gitlens.toggleFileChangesOnly</code> - toggles file changes from the commit<br><code>gitlens.diffWithPrevious</code> - opens changes with the previous revision<br><code>gitlens.revealCommitInView</code> - reveals the commit in the Side Bar<br><code>gitlens.showCommitsInView</code> - searches for commits within the range<br><code>gitlens.showQuickCommitDetails</code> - shows details of the commit<br><code>gitlens.showQuickCommitFileDetails</code> - show file details of the commit<br><code>gitlens.showQuickFileHistory</code> - shows the current file history<br><code>gitlens.showQuickRepoHistory</code> - shows the current branch history<br><code>gitlens.openCommitOnRemote</code> - opens the commit on the remote service (when available)<br><code>gitlens.copyRemoteCommitUrl</code> - copies the remote commit url to the clipboard (when available)<br><code>gitlens.openFileOnRemote</code> - opens the file revision on the remote service (when available)<br><code>gitlens.copyRemoteFileUrl</code> - copies the remote file url to the clipboard (when available)</td>
+<td>Specifies the command executed when clicking the blame status bar item. Default is <code>gitlens.toggleFileBlame</code>. You can choose from a list of commands, such as:<br><br>
+<code>gitlens.toggleFileBlame</code>, <code>gitlens.toggleFileHeatmap</code>, <code>gitlens.toggleFileChanges</code>, <code>gitlens.toggleFileChangesOnly</code>, <code>gitlens.diffWithPrevious</code>, <code>gitlens.revealCommitInView</code>, <code>gitlens.showCommitsInView</code>, <code>gitlens.showQuickCommitDetails</code>, <code>gitlens.showQuickCommitFileDetails</code>, <code>gitlens.showQuickFileHistory</code>, <code>gitlens.showQuickRepoHistory</code>, <code>gitlens.openCommitOnRemote</code>, <code>gitlens.copyRemoteCommitUrl</code>, <code>gitlens.openFileOnRemote</code>, <code>gitlens.copyRemoteFileUrl</code></td>
 </tr>
 <tr>
 <td><code>gitlens.statusBar.dateFormat</code></td>
-<td>Specifies how to format absolute dates (e.g. using the <code>${date}</code> token) in the blame information in the status bar. See the <a href="https://momentjs.com/docs/#/displaying/format/" rel="nofollow">Moment.js docs</a> for valid formats</td>
+<td>Sets the date format using the <code>${date}</code> token. For valid formats, see the <a href="https://momentjs.com/docs/#/displaying/format/" rel="nofollow">Moment.js documentation</a>.</td>
 </tr>
 <tr>
 <td><code>gitlens.statusBar.enabled</code></td>
-<td>Specifies whether to provide blame information in the status bar</td>
+<td>Enables or disables blame information in the status bar.</td>
 </tr>
 <tr>
 <td><code>gitlens.statusBar.format</code></td>
-<td>Specifies the format of the blame information in the status bar. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a> in the GitLens docs. Date formatting is controlled by the <code>gitlens.statusBar.dateFormat</code> setting</td>
+<td>Defines the display format of blame data in the status bar. Refer to <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a>. Controlled alongside <code>gitlens.statusBar.dateFormat</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.statusBar.pullRequests.enabled</code></td>
-<td>Specifies whether to provide information about the Pull Request (if any) that introduced the commit in the status bar. Requires a connection to a supported remote service (e.g. GitHub)</td>
+<td>Shows pull request details for the commit in the status bar, if available. Requires a connected remote (e.g., GitHub).</td>
 </tr>
 <tr>
 <td><code>gitlens.statusBar.reduceFlicker</code></td>
-<td>Specifies whether to avoid clearing the previous blame information when changing lines to reduce status bar "flashing"</td>
+<td>Reduces visual flicker by preventing blame info from clearing when switching lines.</td>
 </tr>
 <tr>
 <td><code>gitlens.statusBar.tooltipFormat</code></td>
-<td>Specifies the format (in markdown) of hover shown over the blame information in the status bar. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a> in the GitLens docs</td>
+<td>Specifies the markdown format used in the hover tooltip over blame info. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a>.</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Hover Settings
+## Hover Settings
+
+Use these settings to control when and how GitLens displays hover popups that show commit details, line changes, avatars, and pull request information.
 
 <table>
 <thead>
@@ -173,73 +193,75 @@ GitLens is highly customizable and provides many configuration settings to allow
 <tbody>
 <tr>
 <td><code>gitlens.hovers.annotations.changes</code></td>
-<td>Specifies whether to provide a <em>changes (diff)</em> hover for all lines when showing blame annotations</td>
+<td>Enables a <em>changes (diff)</em> hover for all lines when blame annotations are shown.</td>
 </tr>
 <tr>
 <td><code>gitlens.hovers.annotations.details</code></td>
-<td>Specifies whether to provide a <em>commit details</em> hover for all lines when showing blame annotations</td>
+<td>Enables a <em>commit details</em> hover for all lines when blame annotations are shown.</td>
 </tr>
 <tr>
 <td><code>gitlens.hovers.annotations.enabled</code></td>
-<td>Specifies whether to provide any hovers when showing blame annotations</td>
+<td>Enables all hovers related to blame annotations.</td>
 </tr>
 <tr>
 <td><code>gitlens.hovers.annotations.over</code></td>
-<td>Specifies when to trigger hovers when showing blame annotations<br><br><code>annotation</code> - only shown when hovering over the line annotation<br><code>line</code> - shown when hovering anywhere over the line</td>
+<td>Controls when annotation hovers trigger:<br><br><code>annotation</code> – hover only on the annotation<br><code>line</code> – hover anywhere on the line</td>
 </tr>
 <tr>
 <td><code>gitlens.hovers.avatars</code></td>
-<td>Specifies whether to show avatar images in hovers</td>
+<td>Displays avatar images in hovers when enabled.</td>
 </tr>
 <tr>
 <td><code>gitlens.hovers.avatarSize</code></td>
-<td>Specifies the size of the avatar images in hovers</td>
+<td>Sets the avatar image size in hover popups.</td>
 </tr>
 <tr>
 <td><code>gitlens.hovers.changesDiff</code></td>
-<td>Specifies whether to show just the changes to the line or the set of related changes in the <em>changes (diff)</em> hover<br><br><code>line</code> - Shows only the changes to the line<br><code>hunk</code> - Shows the set of related changes</td>
+<td>Controls the diff content shown in hovers:<br><br><code>line</code> – shows only changes to the line<br><code>hunk</code> – shows related changes (code hunk)</td>
 </tr>
 <tr>
 <td><code>gitlens.hovers.currentLine.changes</code></td>
-<td>Specifies whether to provide a <em>changes (diff)</em> hover for the current line</td>
+<td>Enables a <em>changes (diff)</em> hover for the current line.</td>
 </tr>
 <tr>
 <td><code>gitlens.hovers.currentLine.details</code></td>
-<td>Specifies whether to provide a <em>commit details</em> hover for the current line</td>
+<td>Enables a <em>commit details</em> hover for the current line.</td>
 </tr>
 <tr>
 <td><code>gitlens.hovers.currentLine.enabled</code></td>
-<td>Specifies whether to provide any hovers for the current line</td>
+<td>Enables all hover popups for the current line.</td>
 </tr>
 <tr>
 <td><code>gitlens.hovers.currentLine.over</code></td>
-<td>Specifies when to trigger hovers for the current line<br><br><code>annotation</code> - only shown when hovering over the line annotation<br><code>line</code> - shown when hovering anywhere over the line</td>
+<td>Controls when hovers appear on the current line:<br><br><code>annotation</code> – hover only on the annotation<br><code>line</code> – hover anywhere on the line</td>
 </tr>
 <tr>
 <td><code>gitlens.hovers.detailsMarkdownFormat</code></td>
-<td>Specifies the format (in markdown) of the <em>commit details</em> hover. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a> in the GitLens docs</td>
+<td>Defines the markdown format used for <em>commit details</em> hovers. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a>.</td>
 </tr>
 <tr>
 <td><code>gitlens.hovers.enabled</code></td>
-<td>Specifies whether to provide any hovers</td>
+<td>Enables or disables all GitLens hovers.</td>
 </tr>
 <tr>
 <td><code>gitlens.hovers.autolinks.enabled</code></td>
-<td>Specifies whether to automatically link external resources in commit messages</td>
+<td>Automatically links external resources mentioned in commit messages.</td>
 </tr>
 <tr>
 <td><code>gitlens.hovers.autolinks.enhanced</code></td>
-<td>Specifies whether to lookup additional details about automatically link external resources in commit messages. Requires a connection to a supported remote service (e.g. GitHub)</td>
+<td>Fetches enhanced details for autolinks using supported remote services (e.g., GitHub).</td>
 </tr>
 <tr>
 <td><code>gitlens.hovers.pullRequests.enabled</code></td>
-<td>Specifies whether to provide information about the Pull Request (if any) that introduced the commit in the hovers. Requires a connection to a supported remote service (e.g. GitHub)</td>
+<td>Displays pull request information (if available) in hovers. Requires connection to a supported remote service.</td>
 </tr>
 </tbody>
 </table>
+
+</table>
 ***
 
-##View Settings
+## View Settings
 
 <table>
 <thead>
@@ -251,104 +273,107 @@ GitLens is highly customizable and provides many configuration settings to allow
 <tbody>
 <tr>
 <td><code>gitlens.views.defaultItemLimit</code></td>
-<td>Specifies the default number of items to show in a view list. Use 0 to specify no limit</td>
+<td>Specifies the default number of items to show in a view list. Use 0 for no limit.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.formats.commits.label</code></td>
-<td>Specifies the format of commits in the views. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a> in the GitLens docs</td>
+<td>Specifies the format of commits in the views. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a> in the GitLens docs.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.formats.commits.description</code></td>
-<td>Specifies the description format of commits in the views. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a> in the GitLens docs</td>
+<td>Specifies the description format of commits in the views. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a> in the GitLens docs.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.formats.files.label</code></td>
-<td>Specifies the format of a file in the views. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#file-tokens"><em>File Tokens</em></a> in the GitLens docs</td>
+<td>Specifies the format of a file in the views. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#file-tokens"><em>File Tokens</em></a> in the GitLens docs.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.formats.files.description</code></td>
-<td>Specifies the description format of a file in the views. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#file-tokens"><em>File Tokens</em></a> in the GitLens docs</td>
+<td>Specifies the description format of a file in the views. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#file-tokens"><em>File Tokens</em></a> in the GitLens docs.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.formats.stashes.label</code></td>
-<td>Specifies the format of stashes in the views. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a> in the GitLens docs</td>
+<td>Specifies the format of stashes in the views. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a> in the GitLens docs.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.formats.stashes.description</code></td>
-<td>Specifies the description format of stashes in the views. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a> in the GitLens docs</td>
+<td>Specifies the description format of stashes in the views. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a> in the GitLens docs.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.formats.stashes.tooltip</code></td>
-<td>Specifies the tooltip format of the stashes in GitLens views</td>
+<td>Specifies the tooltip format of stashes in GitLens views.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.pageItemLimit</code></td>
-<td>Specifies the number of items to show in a each page when paginating a view list. Use 0 to specify no limit</td>
+<td>Specifies the number of items to show per page when paginating a view list. Use 0 for no limit.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.showRelativeDateMarkers</code></td>
-<td>Specifies whether to show relative date markers (<em>Less than a week ago</em>, <em>Over a week ago</em>, <em>Over a month ago</em>, etc) on revision (commit) histories in the views</td>
+<td>Specifies whether to show relative date markers (<em>Less than a week ago</em>, <em>Over a week ago</em>, <em>Over a month ago</em>, etc.) on revision histories in the views.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.commits.files.icon</code></td>
-<td>Specifies how the Commits view will display file icons</td>
+<td>Specifies how the Commits view displays file icons.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.files.icon</code></td>
-<td>Specifies how the Repositories view will display file icons</td>
+<td>Specifies how the Repositories view displays file icons.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.branches.files.icon</code></td>
-<td>Specifies how the Branches view will display file icons</td>
+<td>Specifies how the Branches view displays file icons.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.formats.files.label</code></td>
-<td>Specifies how the Remotes view will display file icons</td>
+<td>Specifies how the Remotes view displays file icons.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.stashes.files.icon</code></td>
-<td>Specifies how the Stashes view will display file icons</td>
+<td>Specifies how the Stashes view displays file icons.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.tags.files.icon</code></td>
-<td>Specifies how the Tags view will display file icons</td>
+<td>Specifies how the Tags view displays file icons.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.worktrees.files.icon</code></td>
-<td>Specifies how the Worktrees view will display file icons</td>
+<td>Specifies how the Worktrees view displays file icons.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.contributors.files.icon</code></td>
-<td>Specifies how the Contributors view will display file icons</td>
+<td>Specifies how the Contributors view displays file icons.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.searchAndCompare.files.icon</code></td>
-<td>Specifies how the Search & Compare view will display file icons</td>
+<td>Specifies how the Search & Compare view displays file icons.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.collapseWorktreesWhenPossible</code></td>
-<td>Specifies whether to try to collapse the opened worktrees into a single (common) repository in the views when possible</td>
+<td>Specifies whether to collapse opened worktrees into a single repository in views when possible.</td>
 </tr>
 <tr>
 <td><code>Gitlens.views.showCurrentBranchOnTo</code></td>
-<td>Specifies whether the current branch is shown at the top of the views</td>
+<td>Specifies whether the current branch is shown at the top of views.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.scm.grouped.default</code></td>
-<td>Specifies the default view to show in the grouped GitLens view on new workspaces/folders (otherwise the last selected view is remembered)</td>
+<td>Specifies the default view shown in the grouped GitLens view for new workspaces/folders (otherwise last selected view is remembered).</td>
 </tr>
 <tr>
 <td><code>gitlens.views.scm.grouped.views</code></td>
-<td>Specifies which views to show in the grouped GitLens view</td>
+<td>Specifies which views to show in the grouped GitLens view.</td>
 </tr>
 </tbody>
 </table>
 
+
 ***
 
-##Commits View Settings
+## Commits View Settings
 
-See also [View Settings](/gitlens/settings/#view-settings)
+See also [View Settings](/gitlens/settings/#view-settings).
+
+These settings control how the GitLens <em>Commits</em> view displays commit data, associated files, and pull request information.
 
 <table>
 <thead>
@@ -360,47 +385,56 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.views.commits.avatars</code></td>
-<td>Specifies whether to show avatar images instead of commit (or status) icons in the <em>Commits</em> view</td>
+<td>Shows avatar images in place of commit or status icons in the <em>Commits</em> view.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.commits.files.compact</code></td>
-<td>Specifies whether to compact (flatten) unnecessary file nesting in the <em>Commits</em> view.<br>Only applies when <code>gitlens.views.commits.files.layout</code> is set to <code>tree</code> or <code>auto</code></td>
+<td>Flattens unnecessary file nesting when file layout is set to <code>tree</code> or <code>auto</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.commits.files.layout</code></td>
-<td>Specifies how the <em>Commits</em> view will display files<br><br><code>auto</code> - automatically switches between displaying files as a <code>tree</code> or <code>list</code> based on the <code>gitlens.views.commits.files.threshold</code> value and the number of files at each nesting level<br><code>list</code> - displays files as a list<br><code>tree</code> - displays files as a tree</td>
+<td>Controls how files are displayed:<br><br>
+<code>auto</code> – switches between <code>tree</code> and <code>list</code> based on the <code>threshold</code><br>
+<code>list</code> – displays a flat file list<br>
+<code>tree</code> – displays a hierarchical file structure</td>
 </tr>
 <tr>
 <td><code>gitlens.views.commits.files.threshold</code></td>
-<td>Specifies when to switch between displaying files as a <code>tree</code> or <code>list</code> based on the number of files in a nesting level in the <em>Commits</em> view<br>Only applies when <code>gitlens.views.commits.files.layout</code> is set to <code>auto</code></td>
+<td>Defines the threshold for switching between <code>tree</code> and <code>list</code> layouts when <code>layout</code> is set to <code>auto</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.commits.pullRequests.enabled</code></td>
-<td>Specifies whether to query for pull requests associated with the current branch and commits in the <em>Commits</em> view. Requires a connection to a supported remote service (e.g. GitHub)</td>
+<td>Enables querying for pull requests associated with the current branch or commits. Requires a connected remote (e.g., GitHub).</td>
 </tr>
 <tr>
 <td><code>gitlens.views.commits.pullRequests.showForBranches</code></td>
-<td>Specifies whether to query for pull requests associated with the current branch and commits in the <em>Commits</em> view. Requires a connection to a supported remote service (e.g. GitHub)</td>
+<td>Shows pull requests linked to the current branch in the <em>Commits</em> view. Requires a connected remote service.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.commits.pullRequests.showForCommits</code></td>
-<td>Specifies whether to show pull requests (if any) associated with the current branch in the <em>Commits</em> view. Requires a connection to a supported remote service (e.g. GitHub)</td>
+<td>Displays pull requests tied to individual commits in the <em>Commits</em> view. Requires a connected remote service.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.commits.reveal</code></td>
-<td>Specifies whether to reveal commits in the <em>Commits</em> view, otherwise they will be revealed in the <em>Repositories</em> view</td>
+<td>Determines whether commits are revealed in the <em>Commits</em> view or the <em>Repositories</em> view.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.commits.showBranchComparison</code></td>
-<td>Specifies whether to show a comparison of the current branch or the working tree with a user-selected reference (branch, tag. etc) in the <em>Commits</em> view<br><br><code>false</code> - hides the branch comparison<br><code>branch</code> - compares the current branch with a user-selected reference<br><code>working</code> - compares the working tree with a user-selected reference</td>
+<td>Controls whether to display branch or working tree comparisons:<br><br>
+<code>false</code> – hides comparison section<br>
+<code>branch</code> – compares current branch to another reference<br>
+<code>working</code> – compares working tree to a selected reference</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Repositories View Settings
+## Repositories View Settings
 
-See also [View Settings](/gitlens/settings/#view-settings)
+See also [View Settings](/gitlens/settings/#view-settings).
+
+These settings customize how repositories are displayed and interacted with in the GitLens <em>Repositories</em> view.
 
 <table>
 <thead>
@@ -412,87 +446,95 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.views.repositories.avatars</code></td>
-<td>Specifies whether to show avatar images instead of commit (or status) icons in the <em>Repositories</em> view</td>
+<td>Displays avatar images instead of icons in the <em>Repositories</em> view.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.autoRefresh</code></td>
-<td>Specifies whether to automatically refresh the <em>Repositories</em> view when the repository or the file system changes</td>
+<td>Automatically refreshes the view when the repository or filesystem changes.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.autoReveal</code></td>
-<td>Specifies whether to automatically reveal repositories in the <em>Repositories</em> view when opening files</td>
+<td>Auto-reveals repositories when opening files.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.branches.layout</code></td>
-<td>Specifies how the <em>Repositories</em> view will display branches<br><br><code>list</code> - displays branches as a list<br><code>tree</code> - displays branches as a tree when branch names contain slashes <code>/</code></td>
+<td>Controls branch layout:<br><br>
+<code>list</code> – shows all branches in a list<br>
+<code>tree</code> – groups branches in a tree structure if names contain <code>/</code></td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.branches.showBranchComparison</code></td>
-<td>Specifies whether to show a comparison of the branch with a user-selected reference (branch, tag. etc) under each branch in the <em>Repositories</em> view view</td>
+<td>Displays comparison with a user-selected reference (branch, tag, etc.) under each branch.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.compact</code></td>
-<td>Specifies whether to show the <em>Repositories</em> view in a compact display density</td>
+<td>Enables a compact display mode in the <em>Repositories</em> view.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.files.compact</code></td>
-<td>Specifies whether to compact (flatten) unnecessary file nesting in the <em>Repositories</em> view. Only applies when <code>gitlens.views.repositories.files.layout</code> is set to <code>tree</code> or <code>auto</code></td>
+<td>Flattens unnecessary file nesting when file layout is set to <code>tree</code> or <code>auto</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.files.layout</code></td>
-<td>Specifies how the <em>Repositories</em> view will display files<br><br><code>auto</code> - automatically switches between displaying files as a <code>tree</code> or <code>list</code> based on the <code>gitlens.views.repositories.files.threshold</code> value and the number of files at each nesting level<br><code>list</code> - displays files as a list<br><code>tree</code> - displays files as a tree</td>
+<td>Controls file display layout:<br><br>
+<code>auto</code> – switches based on file count and nesting<br>
+<code>list</code> – flat file list<br>
+<code>tree</code> – hierarchical file view</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.files.threshold</code></td>
-<td>Specifies when to switch between displaying files as a <code>tree</code> or <code>list</code> based on the number of files in a nesting level in the <em>Repositories</em> view. Only applies when <code>gitlens.views.repositories.files.layout</code> is set to <code>auto</code></td>
+<td>Sets the threshold for switching between tree and list layouts when layout is set to <code>auto</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.includeWorkingTree</code></td>
-<td>Specifies whether to include working tree file status for each repository in the <em>Repositories</em> view</td>
+<td>Includes working tree file status for each repository.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.showBranchComparison</code></td>
-<td>Specifies whether to show a comparison of a user-selected reference (branch, tag. etc) to the current branch or the working tree in the <em>Repositories</em> view</td>
+<td>Displays comparison between a selected reference and the current branch or working tree.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.showBranches</code></td>
-<td>Specifies whether to show the branches for each repository in the <em>Repositories</em> view</td>
+<td>Shows branches for each repository.</td>
 </tr>
 <tr>
 <td><code>itlens.views.repositories.showCommits</code></td>
-<td>Specifies whether to show the commits on the current branch for each repository in the <em>Repositories</em> view</td>
+<td>Displays commits from the current branch for each repository.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.showContributors</code></td>
-<td>Specifies whether to show the contributors for each repository in the <em>Repositories</em> view</td>
+<td>Shows contributors for each repository.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.showIncomingActivity</code></td>
-<td>Specifies whether to show the experimental incoming activity for each repository in the <em>Repositories</em> view</td>
+<td>Displays experimental incoming activity for each repository.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.showRemotes</code></td>
-<td>Specifies whether to show the remotes for each repository in the <em>Repositories</em> view</td>
+<td>Shows configured remotes for each repository.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.showStashes</code></td>
-<td>Specifies whether to show the stashes for each repository in the <em>Repositories</em> view</td>
+<td>Displays stashes for each repository.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.showTags</code></td>
-<td>Specifies whether to show the tags for each repository in the <em>Repositories</em> view</td>
+<td>Shows tags for each repository.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.repositories.showUpstreamStatus</code></td>
-<td>Specifies whether to show the upstream status of the current branch for each repository in the <em>Repositories</em> view</td>
+<td>Displays upstream tracking status of the current branch for each repository.</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##File History View Settings
+## File History View Settings
 
-See also [View Settings](/gitlens/settings/#view-settings)
+See also [View Settings](/gitlens/settings/#view-settings).
+
+These settings configure the behavior and display options for the GitLens <em>File History</em> view.
 
 <table>
 <thead>
@@ -504,20 +546,23 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.views.fileHistory.avatars</code></td>
-<td>Specifies whether to show avatar images instead of status icons in the <em>File History</em> view</td>
+<td>Displays avatar images instead of status icons in the <em>File History</em> view.</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.fileHistoryShowMergeCommits</code></td>
-<td>Specifies whether to <code>show</code> or <code>hide</code> merge commits in file histories</td>
+<td>Controls whether merge commits are shown in file history:<br><br><code>show</code> – includes merge commits<br><code>hide</code> – excludes merge commits</td>
 </tr>
 </tbody>
 </table>
 
+
 ***
 
-##Line History View Settings
+## Line History View Settings
 
-See also [View Settings](/gitlens/settings/#view-settings)
+See also [View Settings](/gitlens/settings/#view-settings).
+
+These settings configure the display behavior of the GitLens <em>Line History</em> view.
 
 <table>
 <thead>
@@ -529,15 +574,18 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.views.lineHistory.avatars</code></td>
-<td>Specifies whether to show avatar images instead of status icons in the <em>Line History</em> view</td>
+<td>Displays avatar images instead of status icons in the <em>Line History</em> view.</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Branch View Settings
+## Branch View Settings
 
-See also [View Settings](/gitlens/settings/#view-settings)
+See also [View Settings](/gitlens/settings/#view-settings).
+
+These settings configure the display and behavior of the GitLens <em>Branches</em> view.
 
 <table>
 <thead>
@@ -549,51 +597,61 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.views.branches.avatars</code></td>
-<td>Specifies whether to show avatar images instead of commit (or status) icons in the <em>Branches</em> view</td>
+<td>Displays avatar images instead of commit or status icons in the <em>Branches</em> view.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.branches.branches.layout</code></td>
-<td>Specifies how the <em>Branches</em> view will display branches<br><br><code>list</code> - displays branches as a list<br><code>tree</code> - displays branches as a tree</td>
+<td>Controls how branches are displayed:<br><br>
+<code>list</code> – shows branches as a list<br>
+<code>tree</code> – groups branches into a tree structure</td>
 </tr>
 <tr>
 <td><code>gitlens.views.branches.files.compact</code></td>
-<td>Specifies whether to compact (flatten) unnecessary file nesting in the <em>Branches</em> view.<br>Only applies when <code>gitlens.views.commits.files.layout</code> is set to <code>tree</code> or <code>auto</code></td>
+<td>Flattens unnecessary file nesting when file layout is set to <code>tree</code> or <code>auto</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.branches.files.layout</code></td>
-<td>Specifies how the <em>Branches</em> view will display files<br><br><code>auto</code> - automatically switches between displaying files as a <code>tree</code> or <code>list</code> based on the <code>gitlens.views.commits.files.threshold</code> value and the number of files at each nesting level<br><code>list</code> - displays files as a list<br><code>tree</code> - displays files as a tree</td>
+<td>Controls file display layout:<br><br>
+<code>auto</code> – switches between <code>tree</code> and <code>list</code> based on the <code>threshold</code><br>
+<code>list</code> – displays a flat list<br>
+<code>tree</code> – displays files hierarchically</td>
 </tr>
 <tr>
 <td><code>gitlens.views.branches.files.threshold</code></td>
-<td>Specifies when to switch between displaying files as a <code>tree</code> or <code>list</code> based on the number of files in a nesting level in the <em>Branches</em> view<br>Only applies when <code>gitlens.views.commits.files.layout</code> is set to <code>auto</code></td>
+<td>Defines the threshold for switching between <code>tree</code> and <code>list</code> layouts when <code>layout</code> is set to <code>auto</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.branches.pullRequests.enabled</code></td>
-<td>Specifies whether to query for pull requests associated with the current branch and commits in the <em>Branches</em> view. Requires a connection to a supported remote service (e.g. GitHub)</td>
+<td>Enables querying for pull requests associated with the current branch and commits. Requires a connected remote service.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.branches.pullRequests.showForBranches</code></td>
-<td>Specifies whether to query for pull requests associated with the current branch and commits in the <em>Branches</em> view. Requires a connection to a supported remote service (e.g. GitHub)</td>
+<td>Displays pull requests linked to the current branch in the <em>Branches</em> view. Requires a connected remote service.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.branches.pullRequests.showForCommits</code></td>
-<td>Specifies whether to show pull requests (if any) associated with the current branch in the <em>Branches</em> view. Requires a connection to a supported remote service (e.g. GitHub)</td>
+<td>Displays pull requests tied to individual commits. Requires a connected remote service.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.branches.reveal</code></td>
-<td>Specifies whether to reveal branches in the <em>Branches</em> view, otherwise they will be revealed in the <em>Repositories</em> view</td>
+<td>Specifies whether branches are revealed in the <em>Branches</em> view or in the <em>Repositories</em> view.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.branches.showBranchComparison</code></td>
-<td>Specifies whether to show a comparison of the branch with a user-selected reference (branch, tag. etc) in the <em>Branches</em> view<br><br><code>false</code> - hides the branch comparison<br><code>branch</code> - compares the current branch with a user-selected reference</td>
+<td>Controls display of branch comparisons:<br><br>
+<code>false</code> – hides comparisons<br>
+<code>branch</code> – compares the current branch with a selected reference</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Remotes View Settings
+## Remotes View Settings
 
-See also [View Settings](/gitlens/settings/#view-settings)
+See also [View Settings](/gitlens/settings/#view-settings).
+
+These settings define how branches, files, and pull requests appear in the GitLens <em>Remotes</em> view.
 
 <table>
 <thead>
@@ -605,51 +663,60 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.views.remotes.avatars</code></td>
-<td>Specifies whether to show avatar images instead of commit (or status) icons in the <em>Remotes</em> view</td>
+<td>Displays avatar images instead of commit or status icons in the <em>Remotes</em> view.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.remotes.branches.layout</code></td>
-<td>Specifies how the <em>Remotes</em> view will display branches<br><br><code>list</code> - displays branches as a list<br><code>tree</code> - displays branches as a tree</td>
+<td>Controls how branches are displayed:<br><br>
+<code>list</code> – shows branches in a flat list<br>
+<code>tree</code> – groups branches hierarchically</td>
 </tr>
 <tr>
 <td><code>gitlens.views.remotes.files.compact</code></td>
-<td>Specifies whether to compact (flatten) unnecessary file nesting in the <em>Remotes</em> view.<br>Only applies when <code>gitlens.views.commits.files.layout</code> is set to <code>tree</code> or <code>auto</code></td>
+<td>Flattens unnecessary file nesting when file layout is set to <code>tree</code> or <code>auto</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.remotes.files.layout</code></td>
-<td>Specifies how the <em>Remotes</em> view will display files<br><br><code>auto</code> - automatically switches between displaying files as a <code>tree</code> or <code>list</code> based on the <code>gitlens.views.commits.files.threshold</code> value and the number of files at each nesting level<br><code>list</code> - displays files as a list<br><code>tree</code> - displays files as a tree</td>
+<td>Controls file display layout:<br><br>
+<code>auto</code> – switches between <code>tree</code> and <code>list</code> depending on nesting<br>
+<code>list</code> – flat file list<br>
+<code>tree</code> – hierarchical file view</td>
 </tr>
 <tr>
 <td><code>gitlens.views.remotes.files.threshold</code></td>
-<td>Specifies when to switch between displaying files as a <code>tree</code> or <code>list</code> based on the number of files in a nesting level in the <em>Remotes</em> view<br>Only applies when <code>gitlens.views.commits.files.layout</code> is set to <code>auto</code></td>
+<td>Defines the threshold for switching between <code>tree</code> and <code>list</code> layouts when <code>layout</code> is set to <code>auto</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.remotes.pullRequests.enabled</code></td>
-<td>Specifies whether to query for pull requests associated with the current branch and commits in the <em>Remotes</em> view. Requires a connection to a supported remote service (e.g. GitHub)</td>
+<td>Enables pull request queries for the current branch and commits. Requires a connected remote service.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.remotes.pullRequests.showForBranches</code></td>
-<td>Specifies whether to query for pull requests associated with the current branch and commits in the <em>Remotes</em> view. Requires a connection to a supported remote service (e.g. GitHub)</td>
+<td>Displays pull requests associated with branches in the <em>Remotes</em> view. Requires a connected remote service.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.remotes.pullRequests.showForCommits</code></td>
-<td>Specifies whether to show pull requests (if any) associated with the current branch in the <em>Remotes</em> view. Requires a connection to a supported remote service (e.g. GitHub)</td>
+<td>Displays pull requests tied to commits in the <em>Remotes</em> view. Requires a connected remote service.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.remotes.reveal</code></td>
-<td>Specifies whether to reveal remotes in the <em>Remotes</em> view, otherwise they will be revealed in the <em>Repositories</em> view</td>
+<td>Determines whether remotes appear in the <em>Remotes</em> view or are shown in the <em>Repositories</em> view.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.remotes.showBranchComparison</code></td>
-<td>Specifies whether to show a comparison of the branch with a user-selected reference (branch, tag. etc) in the <em>Remotes</em> view<br><br><code>false</code> - hides the branch comparison<br><code>branch</code> - compares the current branch with a user-selected reference</td>
+<td>Controls display of branch comparisons:<br><br>
+<code>false</code> – hides comparisons<br>
+<code>branch</code> – compares the current branch with a selected reference</td>
 </tr>
 </tbody>
 </table>
 ***
 
-##Stashes View Settings
+## Stashes View Settings
 
-See also [View Settings](/gitlens/settings/#view-settings)
+See also [View Settings](/gitlens/settings/#view-settings).
+
+These settings control how files and stash entries are displayed in the GitLens <em>Stashes</em> view.
 
 <table>
 <thead>
@@ -661,27 +728,33 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.views.stashes.files.compact</code></td>
-<td>Specifies whether to compact (flatten) unnecessary file nesting in the <em>Stashes</em> view.<br>Only applies when <code>gitlens.views.commits.files.layout</code> is set to <code>tree</code> or <code>auto</code></td>
+<td>Flattens unnecessary file nesting in the <em>Stashes</em> view. Applies when file layout is set to <code>tree</code> or <code>auto</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.stashes.files.layout</code></td>
-<td>Specifies how the <em>Stashes</em> view will display files<br><br><code>auto</code> - automatically switches between displaying files as a <code>tree</code> or <code>list</code> based on the <code>gitlens.views.commits.files.threshold</code> value and the number of files at each nesting level<br><code>list</code> - displays files as a list<br><code>tree</code> - displays files as a tree</td>
+<td>Controls file display layout:<br><br>
+<code>auto</code> – switches between <code>tree</code> and <code>list</code> layouts based on nesting<br>
+<code>list</code> – shows a flat list<br>
+<code>tree</code> – shows a hierarchical view</td>
 </tr>
 <tr>
 <td><code>gitlens.views.stashes.files.threshold</code></td>
-<td>Specifies when to switch between displaying files as a <code>tree</code> or <code>list</code> based on the number of files in a nesting level in the <em>Stashes</em> view<br>Only applies when <code>gitlens.views.commits.files.layout</code> is set to <code>auto</code></td>
+<td>Defines the threshold for switching between <code>tree</code> and <code>list</code> layouts when <code>layout</code> is set to <code>auto</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.stashes.reveal</code></td>
-<td>Specifies whether to reveal stashes in the <em>Stashes</em> view, otherwise they will be revealed in the <em>Repositories</em> view</td>
+<td>Determines whether stashes appear in the <em>Stashes</em> view or the <em>Repositories</em> view.</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Tags View Settings
+## Tags View Settings
 
-See also [View Settings](/gitlens/settings/#view-settings)
+See also [View Settings](/gitlens/settings/#view-settings).
+
+These settings control how Git tags and related files appear in the GitLens <em>Tags</em> view.
 
 <table>
 <thead>
@@ -693,35 +766,43 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.views.tags.avatars</code></td>
-<td>Specifies whether to show avatar images instead of commit (or status) icons in the <em>Tags</em> view</td>
+<td>Displays avatar images instead of commit or status icons in the <em>Tags</em> view.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.tags.branches.layout</code></td>
-<td>Specifies how the <em>Tags</em> view will display tags<br><br><code>list</code> - displays tags as a list<br><code>tree</code> - displays tags as a tree</td>
+<td>Controls tag layout:<br><br>
+<code>list</code> – displays tags as a flat list<br>
+<code>tree</code> – groups tags hierarchically</td>
 </tr>
 <tr>
 <td><code>gitlens.views.tags.files.compact</code></td>
-<td>Specifies whether to compact (flatten) unnecessary file nesting in the <em>Tags</em> view.<br>Only applies when <code>gitlens.views.commits.files.layout</code> is set to <code>tree</code> or <code>auto</code></td>
+<td>Flattens unnecessary file nesting when layout is set to <code>tree</code> or <code>auto</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.tags.files.layout</code></td>
-<td>Specifies how the <em>Tags</em> view will display files<br><br><code>auto</code> - automatically switches between displaying files as a <code>tree</code> or <code>list</code> based on the <code>gitlens.views.commits.files.threshold</code> value and the number of files at each nesting level<br><code>list</code> - displays files as a list<br><code>tree</code> - displays files as a tree</td>
+<td>Controls file display layout:<br><br>
+<code>auto</code> – switches between <code>tree</code> and <code>list</code> layouts based on nesting<br>
+<code>list</code> – shows a flat list<br>
+<code>tree</code> – shows a hierarchical view</td>
 </tr>
 <tr>
 <td><code>gitlens.views.tags.files.threshold</code></td>
-<td>Specifies when to switch between displaying files as a <code>tree</code> or <code>list</code> based on the number of files in a nesting level in the <em>Tags</em> view<br>Only applies when <code>gitlens.views.commits.files.layout</code> is set to <code>auto</code></td>
+<td>Defines the threshold for switching between <code>tree</code> and <code>list</code> layouts when <code>layout</code> is set to <code>auto</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.tags.reveal</code></td>
-<td>Specifies whether to reveal tags in the <em>Tags</em> view, otherwise they will be revealed in the <em>Repositories</em> view</td>
+<td>Determines whether tags are shown in the <em>Tags</em> view or revealed in the <em>Repositories</em> view.</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Worktrees View Settings
+## Worktrees View Settings
 
-See also [View Settings](/gitlens/settings/#view-settings)
+See also [View Settings](/gitlens/settings/#view-settings).
+
+These settings control how worktrees and related information appear in the GitLens <em>Worktrees</em> view.
 
 <table>
 <thead>
@@ -733,45 +814,51 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.views.worktrees.avatars</code></td>
-<td>Specifies whether to show avatar images instead of commit (or status) icons in the <em>Worktrees</em> view</td>
+<td>Displays avatar images instead of commit or status icons in the <em>Worktrees</em> view.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.worktrees.files.compact</code></td>
-<td>Specifies whether to compact (flatten) unnecessary file nesting in the <em>Worktrees</em> view.<br />Only applies when <code>gitlens.views.commits.files.layout</code> is set to <code>tree</code> or <code>auto</code></td>
+<td>Flattens unnecessary file nesting. Applies only when layout is set to <code>tree</code> or <code>auto</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.worktrees.files.layout</code></td>
-<td>Specifies how the <em>Worktrees</em> view will display files<br /><br />`auto` - automatically switches between displaying files as a <code>tree</code> or <code>list</code> based on the <code>gitlens.views.commits.files.threshold</code> value and the number of files at each nesting level<br />`list` - displays files as a list<br />`tree` - displays files as a tree</td>
+<td>Controls how files are displayed:<br><br>
+<code>auto</code> – automatically switches between <code>tree</code> and <code>list</code> views based on the <code>threshold</code><br>
+<code>list</code> – shows files in a flat list<br>
+<code>tree</code> – shows files hierarchically</td>
 </tr>
 <tr>
 <td><code>gitlens.views.worktrees.files.threshold</code></td>
-<td>Specifies when to switch between displaying files as a <code>tree</code> or <code>list</code> based on the number of files in a nesting level in the <em>Worktrees</em> view<br />Only applies when <code>gitlens.views.commits.files.layout</code> is set to <code>auto</code></td>
+<td>Defines when to switch between <code>tree</code> and <code>list</code> layouts based on file count. Applies only when layout is <code>auto</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.worktrees.pullRequests.enabled</code></td>
-<td>Specifies whether to query for pull requests associated with the worktree branch and commits in the <em>Worktrees</em> view. Requires a connection to a supported remote service (e.g. GitHub)</td>
+<td>Enables pull request queries for the current worktree branch and its commits. Requires a supported remote service.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.worktrees.pullRequests.showForBranches</code></td>
-<td>Specifies whether to query for pull requests associated with the worktree branch in the <em>Worktrees</em> view. Requires a connection to a supported remote service (e.g. GitHub) </td>
+<td>Shows pull requests related to the current worktree branch. Requires a supported remote service.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.worktrees.pullRequests.showForCommits</code></td>
-<td>Specifies whether to show pull requests (if any) associated with commits in the <em>Worktrees</em> view. Requires a connection to a supported remote service (e.g. GitHub)</td>
+<td>Displays pull requests (if any) associated with commits in the <em>Worktrees</em> view. Requires a supported remote service.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.worktrees.reveal</code></td>
-<td>Specifies whether to reveal worktrees in the <em>Worktrees</em> view, otherwise they will be revealed in the <em>Repositories</em> view</td>
+<td>Controls whether worktrees appear in the <em>Worktrees</em> view or default to the <em>Repositories</em> view.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.worktrees.showBranchComparison</code></td>
-<td>Specifies whether to show a comparison of the worktree branch with a user-selected reference (branch, tag. etc) in the <em>Worktrees</em> view<br /><br /><code>false</code> - hides the branch comparison<br /><code>branch</code> - compares the current branch with a user-selected reference</td>
+<td>Shows a comparison of the current branch with a user-selected reference:<br><br>
+<code>false</code> – hides comparisons<br>
+<code>branch</code> – compares with a selected reference (e.g., tag or branch)</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Contributors View Settings
+## Contributors View Settings
 
 See also [View Settings](/gitlens/settings/#view-settings)
 
@@ -789,7 +876,7 @@ See also [View Settings](/gitlens/settings/#view-settings)
 </tr>
 <tr>
 <td><code>gitlens.views.contributors.files.compact</code></td>
-<td>Specifies whether to compact (flatten) unnecessary file nesting in the <em>Contributors</em> view.<br>Only applies when <code>gitlens.views.commits.files.layout</code> is set to <code>tree</code> or <code>auto</code></td>
+<td>Specifies whether to compact (flatten) unnecessary file nesting in the <em>Contributors</em> view. Only applies when <code>gitlens.views.commits.files.layout</code> is set to <code>tree</code> or <code>auto</code></td>
 </tr>
 <tr>
 <td><code>gitlens.views.contributors.files.layout</code></td>
@@ -797,7 +884,7 @@ See also [View Settings](/gitlens/settings/#view-settings)
 </tr>
 <tr>
 <td><code>gitlens.views.contributors.files.threshold</code></td>
-<td>Specifies when to switch between displaying files as a <code>tree</code> or <code>list</code> based on the number of files in a nesting level in the <em>Contributors</em> view<br>Only applies when <code>gitlens.views.commits.files.layout</code> is set to <code>auto</code></td>
+<td>Specifies when to switch between displaying files as a <code>tree</code> or <code>list</code> based on the number of files in a nesting level in the <em>Contributors</em> view. Only applies when <code>gitlens.views.commits.files.layout</code> is set to <code>auto</code></td>
 </tr>
 <tr>
 <td><code>gitlens.views.contributors.pullRequests.enabled</code></td>
@@ -817,11 +904,14 @@ See also [View Settings](/gitlens/settings/#view-settings)
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Search & Compare View Settings
+## Search & Compare View Settings
 
-See also [View Settings](/gitlens/settings/#view-settings)
+See also [View Settings](/gitlens/settings/#view-settings).
+
+These settings control the display options for files and avatars in the GitLens <em>Search Commits</em> and <em>Compare</em> views.
 
 <table>
 <thead>
@@ -832,42 +922,45 @@ See also [View Settings](/gitlens/settings/#view-settings)
 </thead>
 <tbody>
 <tr>
-<td><code>gitlens.views.compare.files.threshold</code></td>
-<td>Specifies when to switch between displaying files as a <code>tree</code> or <code>list</code> based on the number of files in a nesting level in the <em>Search Commits</em> view<br>Only applies when <code>gitlens.views.compare.files.layout</code> is set to <code>auto</code></td>
-</tr>
-<tr>
-<td><code>gitlens.views.compare.avatars</code></td>
-<td>Specifies whether to show avatar images instead of commit (or status) icons in the <em>Compare</em> view</td>
-</tr>
-<tr>
 <td><code>gitlens.views.compare.files.compact</code></td>
-<td>Specifies whether to compact (flatten) unnecessary file nesting in the <em>Compare</em> view. Only applies when <code>gitlens.views.compare.files.layout</code> is set to <code>tree</code> or <code>auto</code></td>
+<td>Flattens unnecessary file nesting in the <em>Compare</em> view. Applies when layout is set to <code>tree</code> or <code>auto</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.compare.files.layout</code></td>
-<td>Specifies how the <em>Compare</em> view will display files<br><br><code>auto</code> - automatically switches between displaying files as a <code>tree</code> or <code>list</code> based on the <code>gitlens.views.compare.files.threshold</code> value and the number of files at each nesting level<br><code>list</code> - displays files as a list<br><code>tree</code> - displays files as a tree</td>
+<td>Controls file display in the <em>Compare</em> view:<br><br>
+<code>auto</code> – switches between <code>tree</code> and <code>list</code> based on nesting and threshold<br>
+<code>list</code> – shows files in a flat list<br>
+<code>tree</code> – shows files hierarchically</td>
 </tr>
 <tr>
 <td><code>gitlens.views.compare.files.threshold</code></td>
-<td>Specifies when to switch between displaying files as a <code>tree</code> or <code>list</code> based on the number of files in a nesting level in the <em>Compare</em> view. Only applies when <code>gitlens.views.compare.files.layout</code> is set to <code>auto</code></td>
+<td>Determines when to switch between <code>tree</code> and <code>list</code> layouts based on the number of files in a nesting level. Applies only when layout is <code>auto</code>.</td>
 </tr>
 <tr>
-<td><code>gitlens.views.search.avatars</code></td>
-<td>Specifies whether to show avatar images instead of commit (or status) icons in the <em>Search Commits</em> view</td>
+<td><code>gitlens.views.compare.avatars</code></td>
+<td>Shows avatar images instead of commit or status icons in the <em>Compare</em> view.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.search.files.compact</code></td>
-<td>Specifies whether to compact (flatten) unnecessary file nesting in the <em>Search Commits</em> view<br>Only applies when <code>gitlens.views.compare.files.layout</code> is set to <code>tree</code> or <code>auto</code></td>
+<td>Flattens unnecessary file nesting in the <em>Search Commits</em> view. Applies when layout is set to <code>tree</code> or <code>auto</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.search.files.layout</code></td>
-<td>Specifies how the <em>Search Commits</em> view will display files<br><code>auto</code> - automatically switches between displaying files as a <code>tree</code> or <code>list</code> based on the <code>gitlens.views.compare.files.threshold</code> value and the number of files at each nesting level<br><code>list</code> - displays files as a list<br><code>tree</code> - displays files as a tree</td>
+<td>Controls file display in the <em>Search Commits</em> view:<br><br>
+<code>auto</code> – switches between <code>tree</code> and <code>list</code> based on nesting and threshold<br>
+<code>list</code> – shows files in a flat list<br>
+<code>tree</code> – shows files hierarchically</td>
+</tr>
+<tr>
+<td><code>gitlens.views.search.avatars</code></td>
+<td>Shows avatar images instead of commit or status icons in the <em>Search Commits</em> view.</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##File Blame Settings
+## File Blame Settings
 
 <table>
 <thead>
@@ -879,69 +972,70 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.blame.avatars</code></td>
-<td>Specifies whether to show avatar images in the file blame annotations</td>
+<td>Shows avatar images in file blame annotations.</td>
 </tr>
 <tr>
 <td><code>gitlens.blame.compact</code></td>
-<td>Specifies whether to compact (deduplicate) matching adjacent file blame annotations</td>
+<td>Compacts (deduplicates) adjacent matching blame annotations.</td>
 </tr>
 <tr>
 <td><code>gitlens.blame.dateFormat</code></td>
-<td>Specifies how to format absolute dates (e.g. using the <code>${date}</code> token) in file blame annotations. See the <a href="https://momentjs.com/docs/#/displaying/format/" rel="nofollow">Moment.js docs</a> for valid formats</td>
+<td>Formats absolute dates (e.g., using <code>${date}</code>) in blame annotations. See the <a href="https://momentjs.com/docs/#/displaying/format/" rel="nofollow">Moment.js documentation</a> for valid formats.</td>
 </tr>
 <tr>
 <td><code>gitlens.blame.format</code></td>
-<td>Specifies the format of the file blame annotations. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a> in the GitLens docs. Date formatting is controlled by the <code>gitlens.blame.dateFormat</code> setting</td>
+<td>Specifies the display format of blame annotations. See <a href="https://github.com/eamodio/vscode-gitlens/wiki/Custom-Formatting#commit-tokens"><em>Commit Tokens</em></a>. Date format is controlled by <code>gitlens.blame.dateFormat</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.blame.heatmap.enabled</code></td>
-<td>Specifies whether to provide a heatmap indicator in the file blame annotations</td>
+<td>Enables a heatmap indicator in blame annotations.</td>
 </tr>
 <tr>
 <td><code>gitlens.blame.heatmap.location</code></td>
-<td>Specifies where the heatmap indicators will be shown in the file blame annotations<br><br><code>left</code> - adds a heatmap indicator on the left edge of the file blame annotations<br><code>right</code> - adds a heatmap indicator on the right edge of the file blame annotations</td>
+<td>Determines heatmap indicator placement:<br><br><code>left</code> – left edge of annotations<br><code>right</code> – right edge of annotations</td>
 </tr>
 <tr>
 <td><code>gitlens.blame.highlight.enabled</code></td>
-<td>Specifies whether to highlight lines associated with the current line</td>
+<td>Highlights lines related to the current line.</td>
 </tr>
 <tr>
 <td><code>gitlens.blame.highlight.locations</code></td>
-<td>Specifies where the associated line highlights will be shown<br><br><code>file</code> - adds a file indicator<br><code>line</code> - adds a full-line highlight background color<br><code>overview</code> - adds a decoration to the overview ruler (scroll bar)</td>
+<td>Specifies where highlights appear:<br><br><code>file</code> – file indicator<br><code>line</code> – full-line background highlight<br><code>overview</code> – decoration in the overview ruler</td>
 </tr>
 <tr>
 <td><code>gitlens.blame.ignoreWhitespace</code></td>
-<td>Specifies whether to ignore whitespace when comparing revisions during blame operations</td>
+<td>Ignores whitespace differences when comparing revisions during blame operations.</td>
 </tr>
 <tr>
 <td><code>gitlens.blame.separateLines</code></td>
-<td>Specifies whether file blame annotations will have line separators</td>
+<td>Shows line separators in blame annotations.</td>
 </tr>
 <tr>
 <td><code>gitlens.blame.toggleMode</code></td>
-<td>Specifies how the file blame annotations will be toggled<br><br><code>file</code> - toggles each file individually<br><code>window</code> - toggles the window, i.e. all files at once</td>
+<td>Determines toggle scope:<br><br><code>file</code> – toggles blame per file<br><code>window</code> – toggles blame for all files in the window</td>
 </tr>
 <tr>
 <td><code>gitlens.blame.fontFamily</code></td>
-<td>Specifies the font family of the File Blame annotations</td>
+<td>Sets font family for file blame annotations.</td>
 </tr>
 <tr>
 <td><code>gitlens.blame.fontSize</code></td>
-<td>Specifies the font size of the File Blame annotations</td>
+<td>Sets font size for file blame annotations.</td>
 </tr>
 <tr>
 <td><code>gitlens.blame.fontWeight</code></td>
-<td>Specifies the font weight of the File Blame annotations</td>
+<td>Sets font weight for file blame annotations.</td>
 </tr>
 <tr>
 <td><code>gitlens.blame.fontStyle</code></td>
-<td>Specifies the font style of the File Blame annotations</td>
+<td>Sets font style for file blame annotations.</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##File Changes Settings
+## File Changes Settings
 
 <table>
 <thead>
@@ -953,17 +1047,18 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.changes.locations</code></td>
-<td>Specifies where the indicators of the file changes annotations will be shown<br><br><code>gutter</code> - adds a file indicator<br><code>overview</code> - adds a decoration to the overview ruler (scroll bar)</td>
+<td>Controls where file changes indicators appear:<br><br><code>gutter</code> – shows a file indicator in the gutter<br><code>overview</code> – adds a decoration in the overview ruler (scroll bar)</td>
 </tr>
 <tr>
 <td><code>gitlens.changes.toggleMode</code></td>
-<td>Specifies how the file changes annotations will be toggled<br><br><code>file</code> - toggles each file individually<br><code>window</code> - toggles the window, i.e. all files at once</td>
+<td>Determines toggle scope for file changes annotations:<br><br><code>file</code> – toggles annotations per file<br><code>window</code> – toggles annotations for all files in the window</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##File Heatmap Settings
+## File Heatmap Settings
 
 <table>
 <thead>
@@ -975,29 +1070,30 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.heatmap.ageThreshold</code></td>
-<td>Specifies the age of the most recent change (in days) after which the file heatmap annotations will be cold rather than hot (i.e. will use <code>gitlens.heatmap.coldColor</code> instead of <code>gitlens.heatmap.hotColor</code>)</td>
+<td>Defines the age threshold in days for heatmap coloring. Changes older than this use <code>gitlens.heatmap.coldColor</code>, newer changes use <code>gitlens.heatmap.hotColor</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.heatmap.coldColor</code></td>
-<td>Specifies the base color of the file heatmap annotations when the most recent change is older (cold) than the <code>gitlens.heatmap.ageThreshold</code> value</td>
+<td>Base color for file heatmap annotations when changes are older than the age threshold (cold).</td>
 </tr>
 <tr>
 <td><code>gitlens.heatmap.hotColor</code></td>
-<td>Specifies the base color of the file heatmap annotations when the most recent change is newer (hot) than the <code>gitlens.heatmap.ageThreshold</code> value</td>
+<td>Base color for file heatmap annotations when changes are newer than the age threshold (hot).</td>
 </tr>
 <tr>
 <td><code>gitlens.heatmap.locations</code></td>
-<td>Specifies where the indicators of the file heatmap annotations will be shown<br><br><code>gutter</code> - adds a file indicator<br><code>overview</code> - adds a decoration to the overview ruler (scroll bar)</td>
+<td>Specifies where heatmap indicators appear:<br><br><code>gutter</code> – shows indicator in the gutter<br><code>overview</code> – adds a decoration in the overview ruler (scroll bar)</td>
 </tr>
 <tr>
 <td><code>gitlens.heatmap.toggleMode</code></td>
-<td>Specifies how the file heatmap annotations will be toggled<br><br><code>file</code> - toggles each file individually<br><code>window</code> - toggles the window, i.e. all files at once</td>
+<td>Determines toggle scope for file heatmap annotations:<br><br><code>file</code> – toggles annotations per file<br><code>window</code> – toggles annotations for all files in the window</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Git Command Palette Settings
+## Git Command Palette Settings
 
 <table>
 <thead>
@@ -1009,37 +1105,38 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.gitCommands.closeOnFocusOut</code></td>
-<td>Specifies whether to dismiss the <em>Git Commands Palette</em> when focus is lost (if not, press <code>ESC</code> to dismiss)</td>
+<td>Determines whether the <em>Git Commands Palette</em> dismisses automatically when focus is lost. If disabled, press <kbd>ESC</kbd> to dismiss manually.</td>
 </tr>
 <tr>
 <td><code>gitlens.gitCommands.search.matchAll</code></td>
-<td>Specifies whether to match all or any commit message search patterns</td>
+<td>Controls whether commit message searches match all patterns or any pattern.</td>
 </tr>
 <tr>
 <td><code>gitlens.gitCommands.search.matchCase</code></td>
-<td>Specifies whether to match commit search patterns with or without regard to casing</td>
+<td>Enables case-sensitive matching for commit message searches.</td>
 </tr>
 <tr>
 <td><code>gitlens.gitCommands.search.matchRegex</code></td>
-<td>Specifies whether to match commit search patterns using regular expressions</td>
+<td>Enables regular expression matching for commit message searches.</td>
 </tr>
 <tr>
 <td><code>gitlens.gitCommands.search.showResultsInSideBar</code></td>
-<td>Specifies whether to show the commit search results directly in the quick pick menu, in the Side Bar, or will be based on the context</td>
+<td>Controls where commit search results display: in the quick pick menu, the Side Bar, or context-dependent.</td>
 </tr>
 <tr>
 <td><code>gitlens.gitCommands.skipConfirmations</code></td>
-<td>Specifies which (and when) Git commands will skip the confirmation step, using the format: <code>git-command-name:(menu/command)</code></td>
+<td>Specifies which Git commands skip confirmation prompts. Format: <code>git-command-name:(menu/command)</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.gitCommands.sortBy</code></td>
-<td>Specifies how Git commands are sorted in the <em>Git Command Palette</em><br><br><code>name</code> - sorts commands by name<br><code>usage</code> - sorts commands by last used date</td>
+<td>Specifies sorting order of commands in the <em>Git Command Palette</em>:<br><br><code>name</code> – alphabetically by command name<br><code>usage</code> – by last used date</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Terminal Links Settings
+## Terminal Links Settings
 
 <table>
 <thead>
@@ -1051,13 +1148,14 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.terminalLinks.enabled</code></td>
-<td>Specifies whether to enable terminal links — autolinks in the integrated terminal to quickly jump to more details for commits, branches, tags, and more</td>
+<td>Enables terminal links—autolinks in the integrated terminal that provide quick access to details for commits, branches, tags, and more.</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Remote Provider Integration Settings
+## Remote Provider Integration Settings
 
 <table>
 <thead>
@@ -1069,17 +1167,69 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.integrations.enabled</code></td>
-<td>Specifies whether to enable rich integrations with any supported remote services</td>
+<td>Enables rich integrations with supported remote services.</td>
 </tr>
 <tr>
 <td><code>gitlens.remotes</code></td>
-<td>Specifies custom remote services to be matched with Git remotes to detect custom domains for built-in remote services or provide support for custom remote services<br><br>Supported Types (e.g. <code>"type": "GitHub"</code>):<ul dir="auto"><li>"GitHub"</li><li>"GitLab"</li><li>"Gerrit"</li><li>"GoogleSource"</li><li>"Gitea"</li><li>"AzureDevOps"</li><li>"Bitbucket"</li><li>"BitbucketServer"</li><li>"Custom"</li></ul>Example:<br><code>"gitlens.remotes": [{ "domain": "git.corporate-url.com", "type": "GitHub" }]</code><br><br>Example:<br><code>"gitlens.remotes": [{ "regex": "ssh:\/\/(my\.company\.com):1234\/git\/(.+)", "type": "GitHub" }]</code><br><br>Example:<br><code>"gitlens.remotes": [{</code><br>    <code>"domain": "git.corporate-url.com",</code><br>    <code>"type": "Custom",</code><br>    <code>"name": "My Company",</code><br>    <code>"protocol": "https",</code><br>    <code>"urls": {</code><br>        <code>"repository": "https://git.corporate-url.com/${repo}",</code><br>        <code>"branches": "https://git.corporate-url.com/${repo}/branches",</code><br>        <code>"branch": "https://git.corporate-url.com/${repo}/commits/${branch}",</code><br>        <code>"commit": "https://git.corporate-url.com/${repo}/commit/${id}",</code><br>        <code>"file": "https://git.corporate-url.com/${repo}?path=${file}${line}",</code><br>        <code>"fileInBranch": "https://git.corporate-url.com/${repo}/blob/${branch}/${file}${line}",</code><br>        <code>"fileInCommit": "https://git.corporate-url.com/${repo}/blob/${id}/${file}${line}",</code><br>        <code>"fileLine": "#L${line}",</code><br>        <code>"fileRange": "#L${start}-L${end}"</code><br>        <code>}</code><br>    <code>}]</code><br><br>Example:<br><code>"gitlens.remotes": [{</code><br>    <code>"regex": "ssh:\\/\\/(my\\.company\\.com):1234\\/git\\/(.+)",</code><br>    <code>"type": "Custom",</code><br>    <code>"name": "My Company",</code><br>    <code>"protocol": "https",</code><br>    <code>"urls": {</code><br>        <code>"repository": "https://my.company.com/projects/${repoBase}/repos/${repoPath}",</code><br>        <code>"branches": "https://my.company.com/projects/${repoBase}/repos/${repoPath}/branches",</code><br>        <code>"branch": "https://my.company.com/projects/${repoBase}/repos/${repoPath}/commits/${branch}",</code><br>        <code>"commit": "https://my.company.com/projects/${repoBase}/repos/${repoPath}/commit/${id}",</code><br>        <code>"file": "https://my.company.com/projects/${repoBase}/repos/${repoPath}?path=${file}${line}",</code><br>        <code>"fileInBranch": "https://my.company.com/projects/${repoBase}/repos/${repoPath}/blob/${branch}/${file}${line}",</code><br>        <code>"fileInCommit": "https://my.company.com/projects/${repoBase}/repos/${repoPath}/blob/${id}/${file}${line}",</code><br>        <code>"fileLine": "#L${line}",</code><br>        <code>"fileRange": "#L${start}-L${end}"</code><br>        <code>}</code><br>    <code>}]</code></td>
+<td>Defines custom remote services to match Git remotes for detecting custom domains or supporting additional remote services.<br><br>Supported types include:<br>
+<ul>
+<li>GitHub</li>
+<li>GitLab</li>
+<li>Gerrit</li>
+<li>GoogleSource</li>
+<li>Gitea</li>
+<li>AzureDevOps</li>
+<li>Bitbucket</li>
+<li>BitbucketServer</li>
+<li>Custom</li>
+</ul>
+Examples:<br>
+<pre><code>\"gitlens.remotes\": [{ \"domain\": \"git.corporate-url.com\", \"type\": \"GitHub\" }]</code></pre>
+<pre><code>\"gitlens.remotes\": [{ \"regex\": \"ssh:\\/\\/(my\\.company\\.com):1234\\/git\\/(.+)\", \"type\": \"GitHub\" }]</code></pre>
+Custom example:<br>
+<pre><code>\"gitlens.remotes\": [{
+  \"domain\": \"git.corporate-url.com\",
+  \"type\": \"Custom\",
+  \"name\": \"My Company\",
+  \"protocol\": \"https\",
+  \"urls\": {
+    \"repository\": \"https://git.corporate-url.com/${repo}\",
+    \"branches\": \"https://git.corporate-url.com/${repo}/branches\",
+    \"branch\": \"https://git.corporate-url.com/${repo}/commits/${branch}\",
+    \"commit\": \"https://git.corporate-url.com/${repo}/commit/${id}\",
+    \"file\": \"https://git.corporate-url.com/${repo}?path=${file}${line}\",
+    \"fileInBranch\": \"https://git.corporate-url.com/${repo}/blob/${branch}/${file}${line}\",
+    \"fileInCommit\": \"https://git.corporate-url.com/${repo}/blob/${id}/${file}${line}\",
+    \"fileLine\": \"#L${line}\",
+    \"fileRange\": \"#L${start}-L${end}\"
+  }
+}]</code></pre>
+Another custom example:<br>
+<pre><code>\"gitlens.remotes\": [{
+  \"regex\": \"ssh:\\/\\/(my\\.company\\.com):1234\\/git\\/(.+)\",
+  \"type\": \"Custom\",
+  \"name\": \"My Company\",
+  \"protocol\": \"https\",
+  \"urls\": {
+    \"repository\": \"https://my.company.com/projects/${repoBase}/repos/${repoPath}\",
+    \"branches\": \"https://my.company.com/projects/${repoBase}/repos/${repoPath}/branches\",
+    \"branch\": \"https://my.company.com/projects/${repoBase}/repos/${repoPath}/commits/${branch}\",
+    \"commit\": \"https://my.company.com/projects/${repoBase}/repos/${repoPath}/commit/${id}\",
+    \"file\": \"https://my.company.com/projects/${repoBase}/repos/${repoPath}?path=${file}${line}\",
+    \"fileInBranch\": \"https://my.company.com/projects/${repoBase}/repos/${repoPath}/blob/${branch}/${file}${line}\",
+    \"fileInCommit\": \"https://my.company.com/projects/${repoBase}/repos/${repoPath}/blob/${id}/${file}${line}\",
+    \"fileLine\": \"#L${line}\",
+    \"fileRange\": \"#L${start}-L${end}\"
+  }
+}]</code></pre>
+</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Date & Time Settings
+## Date & Time Settings
 
 <table>
 <thead>
@@ -1091,33 +1241,34 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.defaultDateFormat</code></td>
-<td>Specifies how absolute dates will be formatted by default. See the <a href="https://momentjs.com/docs/#/displaying/format/" rel="nofollow">Moment.js docs</a> for valid formats</td>
+<td>Specifies the default format for absolute dates. See the <a href="https://momentjs.com/docs/#/displaying/format/" rel="nofollow">Moment.js documentation</a> for valid format strings.</td>
 </tr>
 <tr>
 <td><code>gitlens.defaultDateLocale</code></td>
-<td>Specifies the locale, a [BCP 47 language tag](https://en.wikipedia.org/wiki/IETF_language_tag#List_of_major_primary_language_subtags), to use for date formatting, defaults to the VS Code locale. Use <code>system</code> to follow the current system locale, or choose a specific locale, e.g <code>en-US</code> — US English, <code>en-GB</code> — British English, <code>de-DE</code> — German, <code>ja-JP</code> - Japanese, etc.</td>
+<td>Specifies the locale for date formatting, using a <a href="https://en.wikipedia.org/wiki/IETF_language_tag#List_of_major_primary_language_subtags" rel="nofollow">BCP 47 language tag</a>. Defaults to the VS Code locale. Use <code>system</code> to follow the current system locale or specify a locale like <code>en-US</code> (US English), <code>en-GB</code> (British English), <code>de-DE</code> (German), <code>ja-JP</code> (Japanese), etc.</td>
 </tr>
 <tr>
 <td><code>gitlens.defaultDateShortFormat</code></td>
-<td>Specifies how short absolute dates will be formatted by default. See the <a href="https://momentjs.com/docs/#/displaying/format/" rel="nofollow">Moment.js docs</a> for valid formats</td>
+<td>Specifies the default format for short absolute dates. See the <a href="https://momentjs.com/docs/#/displaying/format/" rel="nofollow">Moment.js documentation</a> for valid format strings.</td>
 </tr>
 <tr>
 <td><code>gitlens.defaultDateSource</code></td>
-<td>Specifies whether commit dates should use the authored or committed date</td>
+<td>Determines whether commit dates use the authored date or the committed date.</td>
 </tr>
 <tr>
 <td><code>gitlens.defaultDateStyle</code></td>
-<td>Specifies how dates will be displayed by default</td>
+<td>Specifies the default display style for dates.</td>
 </tr>
 <tr>
 <td><code>gitlens.defaultTimeFormat</code></td>
-<td>Specifies how times will be formatted by default. See the <a href="https://momentjs.com/docs/#/displaying/format/" rel="nofollow">Moment.js docs</a> for valid formats</td>
+<td>Specifies the default format for times. See the <a href="https://momentjs.com/docs/#/displaying/format/" rel="nofollow">Moment.js documentation</a> for valid format strings.</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Menu & Toolbar Settings
+## Menu & Toolbar Settings
 
 <table>
 <thead>
@@ -1129,17 +1280,23 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.menus</code></td>
-<td>Specifies which commands will be added to which menus</td>
+<td>Defines which commands are added to specific menus.</td>
 </tr>
 <tr>
 <td><code>gitlens.fileAnnotations.command</code></td>
-<td>Specifies whether the file annotations button in the editor title shows a menu or immediately toggles the specified file annotations<br><code>null</code> (default) - shows a menu to choose which file annotations to toggle<br><code>blame</code> - toggles file blame annotations<br><code>heatmap</code> - toggles file heatmap annotations<br><code>changes</code> - toggles file changes annotations</td>
+<td>Controls the behavior of the file annotations button in the editor title:<br><br>
+<code>null</code> (default) – shows a menu to select which file annotations to toggle<br>
+<code>blame</code> – toggles file blame annotations<br>
+<code>heatmap</code> – toggles file heatmap annotations<br>
+<code>changes</code> – toggles file changes annotations
+</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Keyboard Shortcut Settings
+## Keyboard Shortcut Settings
 
 <table>
 <thead>
@@ -1151,17 +1308,22 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.keymap</code></td>
-<td>Specifies the keymap to use for GitLens shortcut keys<br><br><code>alternate</code> - adds an alternate set of shortcut keys that start with <code>Alt</code> (⌥ on macOS)<br><code>chorded</code> - adds a chorded set of shortcut keys that start with <code>Ctrl+Shift+G</code> (<code>⌥⌘G</code> on macOS)<br><code>none</code> - no shortcut keys will be added</td>
+<td>Specifies the keymap used for GitLens shortcuts:<br><br>
+<code>alternate</code> – adds alternate shortcuts starting with <kbd>Alt</kbd> (⌥ on macOS)<br>
+<code>chorded</code> – adds chorded shortcuts starting with <kbd>Ctrl+Shift+G</kbd> (⌥⌘G on macOS)<br>
+<code>none</code> – disables all GitLens shortcut keys
+</td>
 </tr>
 <tr>
 <td><code>gitlens.fileAnnotations.dismissOnEscape</code></td>
-<td>Specifies whether pressing the <code>ESC</code> key dismisses the active file annotations</td>
+<td>Determines whether pressing <kbd>ESC</kbd> dismisses active file annotations.</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Modes Settings
+## Modes Settings
 
 <table>
 <thead>
@@ -1173,25 +1335,41 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.mode.active</code></td>
-<td>Specifies the active GitLens mode, if any</td>
+<td>Specifies the currently active GitLens mode, if any.</td>
 </tr>
 <tr>
 <td><code>gitlens.mode.statusBar.enabled</code></td>
-<td>Specifies whether to provide the active GitLens mode in the status bar</td>
+<td>Enables display of the active GitLens mode in the status bar.</td>
 </tr>
 <tr>
 <td><code>gitlens.mode.statusBar.alignment</code></td>
-<td>Specifies the active GitLens mode alignment in the status bar<br><br><code>left</code> - aligns to the left<br><code>right</code> - aligns to the right</td>
+<td>Controls alignment of the active mode display in the status bar:<br><br>
+<code>left</code> – aligns left<br>
+<code>right</code> – aligns right</td>
 </tr>
 <tr>
 <td><code>gitlens.modes</code></td>
-<td>Specifies the user-defined GitLens modes<br><br>Example — adds heatmap annotations to the <em>Reviewing</em> mode<br><code>"gitlens.modes": { "review": { "annotations": "heatmap" } }</code><br><br>Example — adds a new <em>Annotating</em> mode with blame annotations<br><code>"gitlens.modes": {</code><br>    <code>"annotate": {</code><br>        <code>"name": "Annotating",</code><br>        <code>"statusBarItemName": "Annotating",</code><br>        <code>"description": "for root cause analysis",</code><br>        <code>"annotations": "blame",</code><br>        <code>"codeLens": false,</code><br>        <code>"currentLine": false,</code><br>        <code>"hovers": true</code><br>    <code>}</code><br><code>}</code></td>
+<td>Defines user-configured GitLens modes.<br><br>Example: Add heatmap annotations to a <em>Reviewing</em> mode:<br>
+<code>"gitlens.modes": { "review": { "annotations": "heatmap" } }</code><br><br>Example: Define a new <em>Annotating</em> mode with blame annotations:<br>
+<pre><code>"gitlens.modes": {
+  "annotate": {
+    "name": "Annotating",
+    "statusBarItemName": "Annotating",
+    "description": "for root cause analysis",
+    "annotations": "blame",
+    "codeLens": false,
+    "currentLine": false,
+    "hovers": true
+  }
+}</code></pre>
+</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Autolink Settings
+## Autolink Settings
 
 <table>
 <thead>
@@ -1203,10 +1381,14 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.autolinks</code></td>
-<td>Specifies autolinks to external resources in commit messages. Use <code>&lt;num&gt;</code> as the variable for the reference number<br><br>Example to autolink Jira issues: (e.g. <code>JIRA-123 ⟶ https://jira.company.com/issue?query=123</code>)<br><code>"gitlens.autolinks": [{ "prefix": "JIRA-", "url": "https://jira.company.com/issue?query=&lt;num&gt;" }]</code></td>
+<td>Defines autolinks to external resources in commit messages. Use <code>&lt;num&gt;</code> as a placeholder for the reference number.<br><br>Example for Jira issues:<br>
+<code>JIRA-123 ⟶ https://jira.company.com/issue?query=123</code><br>
+<code>"gitlens.autolinks": [{ "prefix": "JIRA-", "url": "https://jira.company.com/issue?query=&lt;num&gt;" }]</code>
+</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
 ## AI Settings - Preview
@@ -1221,7 +1403,7 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.ai.experimental.model</code></td>
-<td>Specifies the AI model to use. The supported models are:
+<td>Specifies the AI model to use. Supported models include:<br>
 <code>vscode</code><br>
 <code>openai:gpt-4</code><br>
 <code>openai:gpt-4o</code><br>
@@ -1244,30 +1426,33 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <code>anthropic:claude-3-5-sonnet-latest</code><br>
 <code>anthropic:claude-3-sonnet-20240229</code><br>
 <code>anthropic:claude-3-5-sonnet-20240620</code><br>
-<code>anthropic:claude-3-5-sonnet-20241022</code><br></td>
+<code>anthropic:claude-3-5-sonnet-20241022</code>
+</td>
 </tr>
 <tr>
 <td><code>gitlens.ai.experimental.vscode.model</code></td>
-<td>Specifies the VS Code extension-provided AI model to use when <code>gitlens.ai.experimental.model</code> is set to <code>vscode</code></td>
+<td>Specifies the VS Code extension-provided AI model to use when <code>gitlens.ai.experimental.model</code> is set to <code>vscode</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.ai.experimental.generateCommitMessage.enabled</code></td>
-<td>Specifies whether to enable GitLens’ experimental, AI-powered, on-demand commit message generation</code></td>
+<td>Enables GitLens’ experimental AI-powered, on-demand commit message generation.</td>
 </tr>
 <tr>
 <td><code>gitlens.ai.experimental.openai.url</code></td>
-<td>Specifies a custom URL to use for access to an OpenAI model via Azure. Azure URLs should be in the following format: https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}/chat/completions?api-version={api-version}</td>
+<td>Specifies a custom Azure URL to access an OpenAI model. Format:<br>
+<code>https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}/chat/completions?api-version={api-version}</code></td>
 </tr>
 <tr>
 <td><code>gitlens.experimental.generateCommitMessagePrompt</code></td>
-<td>Specifies the prompt to use to tell the AI provider how to structure or format the generated commit message — can have fun with it and make your commit messages in the style of a pirate, etc</td>
+<td>Specifies the prompt to guide the AI on structuring or styling generated commit messages (e.g., in the style of a pirate).</td>
 </tr>
 </tbody>
 </table>
 
+
 ***
 
-##Misc Settings
+## Misc Settings
 
 <table>
 <thead>
@@ -1279,155 +1464,171 @@ See also [View Settings](/gitlens/settings/#view-settings)
 <tbody>
 <tr>
 <td><code>gitlens.defaultGravatarsStyle</code></td>
-<td>Specifies the style of the gravatar default (fallback) images<br><br><code>identicon</code> - a geometric pattern<br><code>mp</code> - a simple, cartoon-style silhouetted outline of a person (does not vary by email hash)<br><code>monsterid</code> - a monster with different colors, faces, etc<br><code>retro</code> - 8-bit arcade-style pixelated faces<br><code>robohash</code> - a robot with different colors, faces, etc<br><code>wavatar</code> - a face with differing features and backgrounds</td>
+<td>Specifies the style of default (fallback) gravatar images:<br><br>
+<code>identicon</code> – geometric pattern<br>
+<code>mp</code> – cartoon-style silhouette (same for all emails)<br>
+<code>monsterid</code> – colorful monster faces<br>
+<code>retro</code> – 8-bit pixelated faces<br>
+<code>robohash</code> – robot faces with variations<br>
+<code>wavatar</code> – faces with different features and backgrounds
+</td>
 </tr>
 <tr>
 <td><code>gitlens.liveshare.allowGuestAccess</code></td>
-<td>Specifies whether to allow guest access to GitLens features when using Visual Studio Live Share</td>
+<td>Allows guest access to GitLens features during Visual Studio Live Share sessions.</td>
 </tr>
 <tr>
 <td><code>gitlens.outputLevel</code></td>
-<td>Specifies how much (if any) output will be sent to the GitLens output channel</td>
+<td>Controls the verbosity of output sent to the GitLens output channel.</td>
 </tr>
 <tr>
 <td><code>gitlens.showWelcomeOnInstall</code></td>
-<td>Specifies whether to show the Welcome (Quick Setup) experience on first install</td>
+<td>Shows the Welcome (Quick Setup) experience on first install.</td>
 </tr>
 <tr>
 <td><code>gitlens.showWhatsNewAfterUpgrades</code></td>
-<td>Specifies whether to show the What's New notification after upgrading to new feature releases</td>
+<td>Shows the What's New notification after upgrading to new feature releases.</td>
 </tr>
 <tr>
 <td><code>gitlens.sortBranchesBy</code></td>
-<td>Specifies how branches are sorted in quick pick menus and views</td>
+<td>Determines how branches are sorted in quick pick menus and views.</td>
 </tr>
 <tr>
 <td><code>gitlens.sortContributorsBy</code></td>
-<td>Specifies how contributors are sorted in quick pick menus and views</td>
+<td>Determines how contributors are sorted in quick pick menus and views.</td>
 </tr>
 <tr>
 <td><code>gitlens.sortTagsBy</code></td>
-<td>Specifies how tags are sorted in quick pick menus and views</td>
+<td>Determines how tags are sorted in quick pick menus and views.</td>
 </tr>
 <tr>
 <td><code>gitlens.sortRepositoriesBy</code></td>
-<td>Specifies how repositories are sorted in quick pick menus and views</td>
+<td>Determines how repositories are sorted in quick pick menus and views.</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.abbreviatedShaLength</code></td>
-<td>Specifies the length of abbreviated commit SHAs (shas)</td>
+<td>Length of abbreviated commit SHAs.</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.abbreviateShaOnCopy</code></td>
-<td>Specifies whether to copy full or abbreviated commit SHAs to the clipboard. Abbreviates to the length of <code>gitlens.advanced.abbreviatedShaLength</code></td>
+<td>Determines whether copied commit SHAs are abbreviated to the length of <code>gitlens.advanced.abbreviatedShaLength</code>.</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.blame.customArguments</code></td>
-<td>Specifies additional arguments to pass to the <code>git blame</code> command</td>
+<td>Additional arguments to pass to the <code>git blame</code> command.</td>
 </tr>
 <tr>
 <td><code>gitlens.fileAnnotations.preserveWhileEditing</code></td>
-<td>Specifies whether file annotations are allowed on files with unsaved changes (dirty). Use the <code>gitlens.advanced.blame.delayAfterEdit</code> setting to control how long to wait (defaults to 5s) before the annotation will update while the file is still dirty, which only applies if the file is under the <code>gitlens.advanced.sizeThresholdAfterEdit</code> setting threshold (defaults to 5000 lines)</td>
+<td>Allows file annotations on unsaved (dirty) files. The <code>gitlens.advanced.blame.delayAfterEdit</code> setting controls the delay before updating annotations, which applies only if the file size is under <code>gitlens.advanced.sizeThresholdAfterEdit</code> (default 5000 lines).</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.blame.delayAfterEdit</code></td>
-<td>Specifies the time (in milliseconds) to wait before re-blaming an unsaved document after an edit. Use 0 to specify an infinite wait</td>
+<td>Time (milliseconds) to wait before re-blaming an unsaved document after an edit. Use 0 to wait indefinitely.</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.blame.sizeThresholdAfterEdit</code></td>
-<td>Specifies the maximum document size (in lines) allowed to be re-blamed after an edit while still unsaved. Use 0 to specify no maximum</td>
+<td>Maximum document size (lines) to re-blame after an edit while still unsaved. Use 0 for no maximum.</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.caching.enabled</code></td>
-<td>Specifies whether git output will be cached — changing the default is not recommended</td>
+<td>Enables caching of git output (changing this is not recommended).</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.commitOrdering</code></td>
-<td>Specifies the order by which commits will be shown. If unspecified, commits will be shown in reverse chronological order<br><br><code>date</code> - shows commits in reverse chronological order of the commit timestamp<br><code>author-date</code> - shows commits in reverse chronological order of the author timestamp<br><code>topo</code> - shows commits in reverse chronological order of the commit timestamp, but avoids intermixing multiple lines of history</td>
+<td>Ordering method for commits (default is reverse chronological by commit date):<br><br>
+<code>date</code> – reverse chronological by commit timestamp<br>
+<code>author-date</code> – reverse chronological by author timestamp<br>
+<code>topo</code> – reverse chronological but avoids mixing multiple lines of history
+</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.externalDiffTool</code></td>
-<td>Specifies an optional external diff tool to use when comparing files. Must be a configured <a href="https://git-scm.com/docs/git-config#Documentation/git-config.txt-difftool" rel="nofollow">Git difftool</a>.</td>
+<td>Optional external diff tool for file comparisons (must be a configured <a href="https://git-scm.com/docs/git-config#Documentation/git-config.txt-difftool" rel="nofollow">Git difftool</a>).</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.externalDirectoryDiffTool</code></td>
-<td>Specifies an optional external diff tool to use when comparing directories. Must be a configured <a href="https://git-scm.com/docs/git-config#Documentation/git-config.txt-difftool" rel="nofollow">Git difftool</a>.</td>
+<td>Optional external diff tool for directory comparisons (must be a configured <a href="https://git-scm.com/docs/git-config#Documentation/git-config.txt-difftool" rel="nofollow">Git difftool</a>).</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.fileHistoryFollowsRenames</code></td>
-<td>Specifies whether file histories will follow renames -- will affect how merge commits are shown in histories</td>
+<td>Enables following file history through renames, affecting how merge commits display.</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.fileHistoryShowAllBranches</code></td>
-<td>Specifies whether file histories will show commits from all branches</td>
+<td>Shows commits from all branches in file history views.</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.maxListItems</code></td>
-<td>Specifies the maximum number of items to show in a list. Use 0 to specify no maximum</td>
+<td>Maximum number of items shown in lists. Use 0 for no limit.</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.maxSearchItems</code></td>
-<td>Specifies the maximum number of items to show in a search. Use 0 to specify no maximum</td>
+<td>Maximum number of items shown in search results. Use 0 for no limit.</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.messages</code></td>
-<td>Specifies which messages should be suppressed</td>
+<td>Specifies which messages to suppress.</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.quickPick.closeOnFocusOut</code></td>
-<td>Specifies whether to dismiss quick pick menus when focus is lost (if not, press <code>ESC</code> to dismiss)</td>
+<td>Dismisses quick pick menus when focus is lost. If disabled, press <kbd>ESC</kbd> to dismiss manually.</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.repositorySearchDepth</code></td>
-<td>Specifies how many folders deep to search for repositories</td>
+<td>Depth (number of folders) to search for repositories.</td>
 </tr>
 <tr>
 <td><code>gitlens.advanced.similarityThreshold</code></td>
-<td>Specifies the amount (percent) of similarity a deleted and added file pair must have to be considered a rename</td>
+<td>Percent similarity required for a deleted and added file pair to be considered a rename.</td>
 </tr>
 <tr>
 <td><code>gitlens.strings.codeLens.unsavedChanges.recentChangeAndAuthors</code></td>
-<td>Specifies the string to be shown in place of both the <em>recent change</em> and <em>authors</em> CodeLens when there are unsaved changes</td>
+<td>String shown in place of both <em>recent change</em> and <em>authors</em> CodeLens when there are unsaved changes.</td>
 </tr>
 <tr>
 <td><code>gitlens.strings.codeLens.unsavedChanges.recentChangeOnly</code></td>
-<td>Specifies the string to be shown in place of the <em>recent change</em> CodeLens when there are unsaved changes</td>
+<td>String shown in place of the <em>recent change</em> CodeLens when there are unsaved changes.</td>
 </tr>
 <tr>
 <td><code>gitlens.strings.codeLens.unsavedChanges.authorsOnly</code></td>
-<td>Specifies the string to be shown in place of the <em>authors</em> CodeLens when there are unsaved changes</td>
+<td>String shown in place of the <em>authors</em> CodeLens when there are unsaved changes.</td>
 </tr>
 <tr>
 <td><code>gitlens.worktrees.defaultLocation</code></td>
-<td><code>${userHome}</code> — the path of the user’s home folder<br><code>${workspaceFolder}</code> — the path of the folder opened in VS Code containing the specified repository<br><code>${workspaceFolderBasename}</code> — the name of the folder opened in VS Code containing the specified repository without any slashes (/)</td>
+<td>Path variables:<br><br>
+<code>${userHome}</code> – user's home directory<br>
+<code>${workspaceFolder}</code> – path of the opened folder in VS Code containing the repository<br>
+<code>${workspaceFolderBasename}</code> – name of the opened folder in VS Code without slashes
+</td>
 </tr>
 <tr>
 <td><code>gitlens.visualHistory.allowMultiple</code></td>
-<td>Specifies whether to allow opening multiple instances of the Visual File History in the editor area</td>
+<td>Allows opening multiple Visual File History instances in the editor area.</td>
 </tr>
 <tr>
 <td><code>gitlens.liveshare.enabled</code></td>
-<td>Specifies whether to enable integration with Visual Studio Live Share</td>
+<td>Enables integration with Visual Studio Live Share.</td>
 </tr>
 <tr>
 <td><code>multiDiffEditor.experimental.enabled</code></td>
-<td>Specifies whether to enable VS Code's new multi-diff editor. Requires VS Code 1.85+</td>
+<td>Enables VS Code's experimental multi-diff editor (requires VS Code 1.85+).</td>
 </tr>
 <tr>
 <td><code>gitlens.views.openChangesInMultiDiffEditor</code></td>
-<td>Specifies whether to open multiple changes in VS Code's experimental multi-diff editor (single tab) or in individual diff editors (multiple tabs). <code>multiDiffEditor.experimental.enabled</code> must also be enabled in order to use the multi-diff editor. Requires VS Code 1.85+</td>
+<td>Controls whether to open multiple changes in VS Code's multi-diff editor (single tab) or individual diff editors (multiple tabs). Requires <code>multiDiffEditor.experimental.enabled</code> and VS Code 1.85+.</td>
 </tr>
 <tr>
 <td><code>gitlens.experimental.cloudIntegrations.enabled</code></td>
-<td>Specifies to connect GitHub integration using cloud integration of GitKraken account</td>
+<td>Enables GitHub integration via GitKraken account cloud integration.</td>
 </tr>
 </tbody>
 </table>
+
 ***
 
-##Themable Colors
+## Themable Colors
 
-GitLens defines a set of themable colors which can be provided by vscode themes or directly by the user using `workbench.colorCustomizations`.
+GitLens defines a set of themable colors that can be provided by VS Code themes or customized by users via `workbench.colorCustomizations`.
 
 <table>
 <thead>
@@ -1439,42 +1640,44 @@ GitLens defines a set of themable colors which can be provided by vscode themes 
 <tbody>
 <tr>
 <td><code>gitlens.gutterBackgroundColor</code></td>
-<td>Specifies the background color of the file blame annotations</td>
+<td>Background color of file blame annotations in the gutter.</td>
 </tr>
 <tr>
 <td><code>gitlens.gutterForegroundColor</code></td>
-<td>Specifies the foreground color of the file blame annotations</td>
+<td>Foreground color of file blame annotations in the gutter.</td>
 </tr>
 <tr>
 <td><code>gitlens.gutterUncommittedForegroundColor</code></td>
-<td>Specifies the foreground color of an uncommitted line in the file blame annotations</td>
+<td>Foreground color for uncommitted lines in file blame annotations.</td>
 </tr>
 <tr>
 <td><code>gitlens.trailingLineBackgroundColor</code></td>
-<td>Specifies the background color of the trailing blame annotation</td>
+<td>Background color of trailing blame annotations.</td>
 </tr>
 <tr>
 <td><code>gitlens.trailingLineForegroundColor</code></td>
-<td>Specifies the foreground color of the trailing blame annotation</td>
+<td>Foreground color of trailing blame annotations.</td>
 </tr>
 <tr>
 <td><code>gitlens.lineHighlightBackgroundColor</code></td>
-<td>Specifies the background color of the associated line highlights in blame annotations</td>
+<td>Background color for associated line highlights in blame annotations.</td>
 </tr>
 <tr>
 <td><code>gitlens.lineHighlightOverviewRulerColor</code></td>
-<td>Specifies the overview ruler color of the associated line highlights in blame annotations</td>
+<td>Overview ruler color for associated line highlights in blame annotations.</td>
 </tr>
 <tr>
 <td><code>gitlens.focus.allowMultiple</code></td>
-<td>Specifies whether to allow opening multiple instances of the Focus in the editor area</td>
+<td>Allows opening multiple instances of the Focus feature in the editor area.</td>
 </tr>
 </tbody>
 </table>
 
+
 ***
 
 ## Commit Graph Settings
+
 <table>
 <thead>
 <tr>
@@ -1485,35 +1688,42 @@ GitLens defines a set of themable colors which can be provided by vscode themes 
 <tbody>
 <tr>
 <td><code>gitlens.graph.showUpstreamStatus</code></td>
-<td>Toggle the upstream (ahead/behind) indicators on branches</td>
+<td>Enables or disables upstream (ahead/behind) indicators on branches.</td>
 </tr>
 <tr>
 <td><code>gitlens.graph.pullRequests</code></td>
-<td>Toggle pull request icons</td>
+<td>Enables or disables pull request icons in the Commit Graph.</td>
 </tr>
 <tr>
 <td><code>gitlens.graph.dimMergeCommits</code></td>
-<td>Specifies whether to dim (deemphasize) merge commit rows</td>
+<td>Dims (deemphasizes) merge commit rows in the graph.</td>
 </tr>
 <tr>
 <td><code>gitlens.graph.scrollRowPadding</code></td>
-<td>Specifies the number of rows from the edge at which the graph will scroll when using keyboard or search to change the selected row</td>
+<td>Number of rows from the edge at which the graph scrolls when changing the selected row via keyboard or search.</td>
 </tr>
 <tr>
 <td><code>gitlens.graph.experimental.location</code></td>
-<td>Specifies the location in which the Commit Graph will be shown<br><br> <code>tab</code> - Shows the Commit Graph in a tab in the editor area <br><br> <code>view</code> - Shows the Commit Graph in the side bar and can be dragged and dropped into any side bar, secondary side bar, or panel locations</td>
+<td>Location where the Commit Graph is shown:<br><br>
+<code>tab</code> – in a tab in the editor area<br>
+<code>view</code> – in the side bar, draggable to side bar, secondary side bar, or panel locations
+</td>
 </tr>
 <tr>
 <td><code>gitlens.graph.layout</code></td>
-<td>Specifies the default layout in which the Commit Graph will be shown. Can be `panel` (default) or `editor`. This is honored when opening the commit graph from the command palette.</td>
+<td>Default layout for the Commit Graph. Options:<br><br>
+<code>panel</code> (default) – shows in a panel<br>
+<code>editor</code> – shows in the editor area.<br>
+Honored when opening the Commit Graph from the command palette.
+</td>
 </tr>
 <tr>
 <td><code>gitlens.graph.allowMultiple</code></td>
-<td>Specifies whether to allow opening multiple instances of the Commit Graph in the editor area</td>
+<td>Allows opening multiple Commit Graph instances in the editor area.</td>
 </tr>
 <tr>
 <td><code>gitlens.graph.sidebar.enabled</code></td>
-<td>Specifies whether to show a sidebar on the Commit Graph</td>
+<td>Shows or hides the sidebar in the Commit Graph.</td>
 </tr>
 </tbody>
 </table>
@@ -1532,14 +1742,15 @@ GitLens defines a set of themable colors which can be provided by vscode themes 
 <tbody>
 <tr>
 <td><code>gitlens.cloudPatches.enabled</code></td>
-<td>Specifies whether to enable Cloud Patches (defaults to true)</td>
+<td>Enables or disables Cloud Patches. Defaults to <code>true</code>.</td>
 </tr>
 </tbody>
 </table>
 
+
 ***
 
-## Launchpad Settings 
+## Launchpad Settings
 
 <table>
 <thead>
@@ -1551,55 +1762,55 @@ GitLens defines a set of themable colors which can be provided by vscode themes 
 <tbody>
 <tr>
 <td><code>gitlens.launchpad.ignoredRepositories</code></td>
-<td>Specifies an array of repositories with <code>owner/name</code> format to ignore in the Launchpad</td>
+<td>List of repositories (in <code>owner/name</code> format) to ignore in Launchpad.</td>
 </tr>
 <tr>
 <td><code>gitlens.launchpad.ignoredOrganizations</code></td>
-<td>Specifies an array of organizations (or users) to ignore in the Launchpad</td>
+<td>List of organizations or users to ignore in Launchpad.</td>
 </tr>
 <tr>
 <td><code>gitlens.launchpad.staleThreshold</code></td>
-<td>Specifies a value in days after which a pull request is considered stale and moved to the Other category</td>
+<td>Number of days after which a pull request is considered stale and moved to the "Other" category.</td>
 </tr>
 <tr>
 <td><code>gitlens.launchpad.indicator.enabled</code></td>
-<td>Specifies whether to show the Launchpad indicator in the status bar</td>
+<td>Enables the Launchpad indicator in the status bar.</td>
 </tr>
 <tr>
 <td><code>gitlens.launchpad.indicator.icon</code></td>
-<td>Specifies the style of the Launchpad indicator icon</td>
+<td>Style of the Launchpad indicator icon.</td>
 </tr>
 <tr>
 <td><code>gitlens.launchpad.indicator.label</code></td>
-<td>Specifies the style of the Launchpad indicator label</td>
+<td>Style of the Launchpad indicator label.</td>
 </tr>
 <tr>
 <td><code>gitlens.launchpad.indicator.groups</code></td>
-<td>Specifies which critical categories of pull requests to summarize in the indicator tooltip</td>
+<td>Critical pull request categories to summarize in the indicator tooltip.</td>
 </tr>
 <tr>
 <td><code>gitlens.launchpad.indicator.useColors</code></td>
-<td>Specifies whether to use colors in the indicator</td>
+<td>Enables color usage in the Launchpad indicator.</td>
 </tr>
 <tr>
 <td><code>gitlens.launchpad.indicator.openInEditor</code></td>
-<td>Specifies whether to open the Launchpad in the editor when clicked</td>
+<td>Opens the Launchpad in the editor when the indicator is clicked.</td>
 </tr>
 <tr>
 <td><code>gitlens.launchpad.indicator.polling.enabled</code></td>
-<td>Specifies whether to regularly check for changes to pull requests</td>
+<td>Enables regular polling for pull request changes.</td>
 </tr>
 <tr>
 <td><code>gitlens.launchpad.indicator.polling.interval</code></td>
-<td>Specifies the interval in minutes to check for changes to pull requests</td>
+<td>Polling interval in minutes for checking pull request changes.</td>
 </tr>
 <tr>
 <td><code>gitlens.views.launchpad.enabled</code></td>
-<td>(Experimental) Specifies whether to enable an experimental Launchpad view</td>
+<td>(Experimental) Enables the experimental Launchpad view.</td>
 </tr>
 <tr>
 <td><code>gitlens.launchpad.includedOrganizations</code></td>
-<td>Specifies which organizations to include in Launchpad</td>
+<td>Organizations to include in Launchpad.</td>
 </tr>
 </tbody>
 </table>

--- a/gitlens/home-view.md
+++ b/gitlens/home-view.md
@@ -1,59 +1,91 @@
 ---
-
-title: Home View
-description: Overview of the GitLens Home View interface and features
+title: GitLens Home View Overview
+description: Learn how the GitLens Home View helps you track current work, plan next steps, and review recent activity
 taxonomy:
     category: gitlens
-    
 ---
+<kbd>Last updated: July 2025</kbd>
+
 ## Overview
 
 <a href="vscode://eamodio.gitlens/link/command/home">Open the Home View in GitLens</a>
 
-The GitLens Home View is designed to streamline your workflows by answering three key questions throughout your day and providing paths to take action on work.
+The GitLens Home View helps you stay focused by organizing your work around three key questions:
 
-1. [What am I actively working on now?](/gitlens/home-view/#active-work-section)
+1. [What am I actively working on now?](/gitlens/home-view/#View-Your-Active-Repository-and-Branch)
 2. [What should I work on next?](/gitlens/home-view/#launchpad-section)
 3. [What have I worked on recently?](/gitlens/home-view/#recent-section)
 
-<div class='embed-container embed-container--16-9'>
+Each section in the Home View offers direct insights and actionable links to help you manage tasks efficiently across your repositories.
+
+<figure>
+  <div class='embed-container embed-container--16-9'>
     <iframe width="560" height="315" src="https://www.youtube.com/embed/jVzhyVBgNGg?si=T5hmEEe0jO09RNbl" title="Introducing the GitLens Home View" frameborder="0" allowfullscreen></iframe>
-</div>
+  </div>
+  <figcaption style="text-align:center; color:#888">Video overview: Introducing the GitLens Home View</figcaption>
+</figure>
 
-## Connecting Integrations
+## Connect to GitHub, GitLab, and Jira
 
-GitLens integrates with hosting and issue services like GitHub, GitLab, and Jira to help you monitor and take action on branches, issues, and pull requests. Integrations can be connected from the top of the Home View. Some features that leverage integrations are enhanced with <a href="https://help.gitkraken.com/gitlens/gitlens-community-vs-gitlens-pro/">GitLens Pro</a>.
+GitLens integrates with popular code hosting and issue tracking services—including GitHub, GitLab, and Jira—to help you monitor branches, track issues, and manage pull requests.
 
-<img src="/wp-content/uploads/home-view-integrations.png" class="help-center-img img-bordered">
+You can connect integrations directly from the top of the Home View.
 
-## Active Work Section
+Some advanced integration features are available with <a href="https://help.gitkraken.com/gitlens/gitlens-community-vs-gitlens-pro/">GitLens Pro features</a>.
 
-At the top of the GitLens Home View, you can see the state of your active repository and current branch. This section provides quick access to actions like syncing (push, pull, fetch), switching the active repo, viewing working directory changes, and more. You can also quickly open the <a href="https://help.gitkraken.com/gitlens/gitlens-home/#commit-graph">GitLens Commit Graph</a> from the icon in the header.
+<figure>
+  <img src="/wp-content/uploads/home-view-integrations.png" alt="GitLens Home View showing integration panel" class="help-center-img img-bordered">
+  <figcaption style="text-align:center; color:#888">GitLens Home View integration panel</figcaption>
+</figure>
 
-<img src="/wp-content/uploads/home-view-active-work.png" class="help-center-img img-bordered">
+## View Your Active Repository and Branch
 
-When integrations are connected and issues or pull requests are associated with your branch, GitLens Pro will group them with branches. This allows you to check PR statuses, continue reviews, or revisit issue specifications as you work. If you haven't opened a PR yet or need to associate a branch with an existing issue, GitLens will guide you through the process.
+At the top of the GitLens Home View, you can see the current state of your active repository and branch.
 
-## Launchpad Section `Pro`
+This section gives you quick access to:
+- Sync actions (push, pull, fetch)
+- Switch active repositories
+- View working directory changes
+- Launch the <a href="https://help.gitkraken.com/gitlens/gitlens-home/#commit-graph">GitLens Commit Graph</a>
+
+<figure>
+  <img src="/wp-content/uploads/home-view-active-work.png" alt="GitLens Home View showing active repository section" class="help-center-img img-bordered">
+  <figcaption style="text-align:center; color:#888">GitLens Home View active repository section</figcaption>
+</figure>
+
+When you connect integrations and associate issues or pull requests with your current branch, GitLens Pro groups them for streamlined access. You can check pull request statuses, resume reviews, or revisit linked issue details—all from within this view.
+
+If a pull request isn’t open or your branch isn't yet linked to an issue, GitLens guides you through connecting it.
+
+
+## Plan Next Steps with Launchpad <span class="badge badge--pro">Pro</span>
+
 <div class='callout callout--warning'>
-    <p>This feature is only available for Pro subscription tiers or higher</p>
+    <p>This feature is available with GitLens Pro or higher subscription tiers.</p>
 </div>
-The Launchpad Section highlights the most important tasks to work on next. It leverages integrations to list critical pull requests that need your attention and allows you to start work on issues assigned to you by creating branches and worktrees.
 
-<img src="/wp-content/uploads/home-view-next.png" class="help-center-img img-bordered">
+The Launchpad section highlights upcoming priorities to help you decide what to work on next. It surfaces pull requests needing your review and lets you start new work by creating branches and worktrees for issues assigned to you.
 
-### Launchpad Summary
+<figure>
+  <img src="/wp-content/uploads/home-view-next.png" alt="GitLens Home View showing Launchpad section" class="help-center-img img-bordered">
+  <figcaption style="text-align:center; color:#888">GitLens Home View Launchpad section</figcaption>
+</figure>
 
-The Launchpad Summary shows how many pull requests are blocking your team and why. With GitLens Pro, you can click any status in this list to view the details of each pull request in <a href="https://help.gitkraken.com/gitlens/gitlens-features/#launchpad-pro">Launchpad</a>. From there, you can take actions like checking out a PR in a worktree to review it quickly without disrupting your current working directory.
+### Review Pull Request Statuses
 
-### Starting Work on an issue
+The Launchpad Summary shows how many pull requests are blocking your team and provides reasons for each. With GitLens Pro, you can click a status to open the related pull request in <a href="https://help.gitkraken.com/gitlens/gitlens-features/#launchpad-pro">Launchpad</a>. You can then take actions like checking out the PR in a worktree, enabling fast reviews without changing your main branch.
 
-Quickly create branches and worktrees for issues assigned to you by clicking "Start Work on an Issue". This will display a list of issues assigned to you from connected integrations and guide you through creating a branch named after the issue. The issue will then be associated with the branch in GitLens, allowing you to refer back to it while working.
+### Start Work on an Issue
 
-## Recent Section
+To begin working on an assigned issue, click **Start Work on an Issue**. GitLens displays a list of assigned issues from connected integrations and helps you create a branch named after the issue. The issue becomes linked to the new branch, keeping context visible throughout your work.
 
-The Recent section helps reduce the pain of context switching by keeping track of recent branches, worktrees, and pull requests you've interacted with within a specific timeframe. This makes it easy to return to work you may have switched away from. It's also helpful for finding recently merged or closed PRs that you worked on.
+## Return to Recent Work
 
-To save space, associated branches and issues are collapsed by default in this section. You can click to expand them for additional context.
+The Recent section minimizes context switching by showing your recent branches, worktrees, and pull requests. This makes it easy to return to recent tasks or review merged and closed pull requests.
 
-<img src="/wp-content/uploads/home-view-recent.png" class="help-center-img img-bordered">
+By default, the section collapses details like associated issues and branches to reduce clutter. Click any item to expand it for more context.
+
+<figure>
+  <img src="/wp-content/uploads/home-view-recent.png" alt="GitLens Home View showing recent activity section" class="help-center-img img-bordered">
+  <figcaption style="text-align:center; color:#888">GitLens Home View recent activity section</figcaption>
+</figure>


### PR DESCRIPTION
Tacking the passive voice in the settings page. Made an active effort to keep table structure and settings order intact

Also introduces a home view overview, which explains the Home View, integrations, active repository and branch, Launchpad, and recent work sections.
