### PR TITLE
Improve readability of GitLens sidebars

### DIFF
--- a/gitlens/GL-GK-Account.md
+++ b/gitlens/GL-GK-Account.md
@@ -5,6 +5,8 @@ taxonomy:
   category: gitlens
 ---
 
+<kbd>Last updated: July 2025</kbd>
+
 Your GitKraken account is your key to unlocking the most personal experience across GitKraken products.
 
 <figure class='callout callout--basic'>

--- a/gitlens/side-bar.md
+++ b/gitlens/side-bar.md
@@ -1,56 +1,75 @@
 ---
-
-title: Sidebar
-description: GitLens sidebar views
+title: Using the GitLens Sidebar
+description: Explore GitLens sidebar views for working with repositories, authors, commits, and branches.
 taxonomy:
-    category: gitlens
-
+  category: gitlens
 ---
 
-GitLens adds many side bar views to provide additional rich functionality. There are three side bars with GitLens views in them: GitLens Inspect, GitLens, and Source Control.
+<kbd>Last updated: July 2025</kbd>
+
+GitLens provides multiple sidebars that extend the functionality of Visual Studio Code, making it easier to navigate and understand your Git repositories. These include:
+
+- **GitLens Inspect** — View blame annotations, code lenses, and commit details.
+- **GitLens** — Access features like commit history, branches, and remotes.
+- **Source Control** — Integrates with GitLens to enhance the built-in source control panel.
 
 Features marked with `PRO` require a [trial or paid plan](https://www.gitkraken.com/gitlens/pricing) for use on privately hosted repos
 Features marked with `PREVIEW` require a GitKraken Account, with access level based on your [plan](https://www.gitkraken.com/gitlens/pricing), e.g. Community, Pro, etc
 
 ***
 
-## Side Bars
+## Use the GitLens Sidebars
 
-### GitLens Inspect
+GitLens offers three sidebars in Visual Studio Code that enhance Git workflows with rich visualizations, insights, and collaboration tools.
 
-GitLens Inspect side bar focuses on providing contextual information and insights to what you're actively working on. This side bar includes:
+### GitLens Inspect Sidebar
 
-- Commit Details
-- Overview
-- Line History
-- File History
-- Visual File History
-- Search & Compare
+The **GitLens Inspect** sidebar provides contextual information about your current file, line, or repository activity. Use it to dive into commit details, history, and comparisons.
 
-<img src="/wp-content/uploads/gl-inspect-side-bar.png" class="help-center-img img-bordered"> 
+This sidebar includes:
 
-### GitLens
+- **Commit Details**
+- **Overview**
+- **Line History**
+- **File History**
+- **Visual File History**
+- **Search & Compare**
 
-The GitLens side bar is the home of GitKraken teams and collaboration services (e.g. GitKraken Workspaces) as well as discovery, help, and support. This side bar includes:
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-inspect-side-bar.png" alt="GitLens Inspect sidebar overview">
+</figure>
 
-- Home View
-- GitKraken Workspaces
-- GitKraken Account
-- Cloud Patches `Pro`
-- Launchpad `Pro`
+### GitLens Sidebar
 
-<img src="/wp-content/uploads/gl-home-view-v16.png" class="help-center-img img-bordered"> 
+The **GitLens** sidebar centralizes collaboration features and user tools, including GitKraken Workspaces and account settings.
 
-#### Home view
+This sidebar includes:
 
-A view to see what you are working on, what you need to work on next, and what you have recently worked on. <a href="https://gitkraken.dev/settings/integrations?source=help_center&product=gitlens" target="_blank">Connect your provider and issue integrations</a> to fully utilize the Home view. This view includes the following sections:
-- The **REPOSITORY** section shows your current repository and branch, alongside the repository state and actions for syncing (push, pull, fetch), switching repos/branches, and viewing working directory changes. If your branch is tied to a pull request or issue, GitLens surfaces those details so you can check PR status, continue reviews, or revisit issue specs. GitLens will also guide you to start a PR from your current branch if it can't find one.
-- The **LAUNCHPAD** section unblocks you and your team by showing pull requests that need your review, are blocked, or are ready to merge. Quickly jump to PRs to review, comment, or merge. With the new Start work action, you can easily begin a new branch or worktree, or generate one from an existing issue.
-- The **RECENT** section lets you quickly return to previous work by showing recent branches, worktrees, and PRs with activity for your chosen timeframe.
+- **Home View**
+- **GitKraken Workspaces**
+- **GitKraken Account**
+- **Cloud Patches** `PRO`
+- **Launchpad** `PRO`
 
-### Source Control
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-home-view-v16.png" alt="GitLens sidebar showing Home view">
+</figure>
 
-Source Control contains side bar that are only focused on your repositories. This side bar includes:
+#### Home View Details
+
+The **Home View** provides visibility into current tasks and recent activity. To get the most out of this view, [connect your Git provider and issue integrations](https://gitkraken.dev/settings/integrations?source=help_center&product=gitlens).
+
+Sections include:
+
+- **REPOSITORY** — Displays the active repository and branch, sync status, and actions for fetch/push/pull. Shows linked PRs or issues when available, or offers to start a new PR.
+- **LAUNCHPAD** — Highlights pull requests needing review, those blocked, or ready to merge. Start new branches or worktrees tied to issues.
+- **RECENT** — Quickly access recent branches, PRs, and worktrees.
+
+### Source Control Sidebar
+
+The **Source Control** sidebar enhances VS Code’s native Git interface with additional GitLens-powered views.
+
+This sidebar includes:
 
 - Commits
 - Branches
@@ -61,351 +80,414 @@ Source Control contains side bar that are only focused on your repositories. Thi
 - Contributors
 - Repositories
 
-<img src="/wp-content/uploads/gl-source-control.gif" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-source-control.gif" alt="GitLens Source Control sidebar with enhanced Git views">
+</figure>
 
-Views can be detached to be [moved](/gitlens/side-bar/#moving-views) or reattached from the ellipsis icon. 
+Views can be detached from the sidebar and [moved](/gitlens/side-bar/#moving-views) or reattached using the ellipsis icon menu.
 
-<img src="/wp-content/uploads/gl-source-control-detach.png" class="help-center-img img-bordered"> 
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-source-control-detach.png" alt="Detaching GitLens views from the Source Control sidebar">
+</figure>
 
-### Moving Views
+### Move Views Between Sidebars
 
-Any view can be moved between GitLens Inspect, GitLens, and the Source Control Sidebar. To move a view, simply drag and drop the view into the desired sidebar. 
+You can move any GitLens view between the GitLens Inspect, GitLens, and Source Control sidebars. To move a view, simply drag and drop it to the desired sidebar.
 
-<img src="/wp-content/uploads/move-view.gif" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/move-view.gif" alt="Drag and drop GitLens views to reposition them between sidebars">
+</figure>
 
-To revert back to the default view locations, open the command palette (<kdb>command/ctrl + shift + P</kdb>) and use the command <kdb>View: Reset View Locations</kdb>
+To restore the default layout, open the Command Palette (<kbd>Cmd/Ctrl + Shift + P</kbd>) and run:
+
+<kbd>View: Reset View Locations</kbd>
 
 ***
  
-## Commits view
+## Commits View
 
-<img src="/wp-content/uploads/commits-view.png" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/commits-view.png" alt="GitLens Commits view">
+</figure>
 
-A [customizable](/gitlens/settings/#commits-view-settings) view to visualize, explore, and manage Git commits
+A [customizable](/gitlens/settings/#commits-view-settings) view to visualize, explore, and manage Git commits.
 
-The _Commits_ view lists all of the commits on the current branch, and additionally provides:
+The **Commits** view displays all commits on the current branch. It also provides:
 
-- a toggle to switch between showing all commits or just your own commits
-- a toggle to change the file layout: list, tree, auto
-- a branch comparison tool **(Compare <current branch> with <branch, tag, or ref>)** — [optionally](/gitlens/gitlens-settings/#commits-view-settings) shows a comparison of the current branch (or working tree) to a user-selected reference
-    -  **Behind** — lists the commits that are missing from the current branch (i.e. behind) but exist in the selected reference
-        - **number of files changed** — lists all of the files changed in the behind commits
-    - **Ahead** — lists the commits that the current branch has (i.e. ahead) but are missing in the selected reference
-        - **number of files changed** — lists all of the files changed in the ahead commits
-        - **number of files changed** — lists all of the files changed between the compared references
-- the current branch status — shows the upstream status of the current branch
-    - **Publish \<current branch\> to <remote>** — shown when the current branch has not been published to a remote
-    - **Up to date with \<remote\>** — shown when the current branch is up to date with the upstream remote
-    - **Changes to pull from \<remote\>** — lists all of the commits waiting to be pulled when the current branch has commits that are waiting to be pulled from the upstream remote
-    - **Changes to push to <remote>** — lists of all the files changed in the unpublished commits when the current branch has (unpublished) commits that waiting to be pushed to the upstream remote
-    - **Merging into \<branch\>** or **Resolve conflicts before merging into \<branch\>** — lists any conflicted files. Conflicted files show comparisons with the common base of the current and incoming changes to aid in resolving the conflict by making it easier to see where changes originated Merging
-<img src="/wp-content/uploads/commits-view-merge.png" class="help-center-img img-bordered">
+- A toggle to show all commits or only your own
+- A toggle to switch file layout: list, tree, or auto
+- A branch comparison tool — compare the current branch (or working tree) with a selected branch, tag, or ref
+  - **Behind** — shows commits missing from the current branch
+  - **Ahead** — shows commits present on the current branch but not on the selected reference
+- Branch status with upstream info:
+  - **Publish** — option to publish if not yet pushed
+  - **Up to date** — when synced with remote
+  - **Changes to pull** — if commits are available on the remote
+  - **Changes to push** — if there are local unpublished commits
+  - **Merging or rebasing** — indicates in-progress merge or rebase actions and lists conflicted files
 
-    - **Rebasing \<branch\>** or **Resolve conflicts to continue rebasing \<branch\>** — shows the number of rebase steps left, the commit the rebase is paused at, and lists any conflicted files. Conflicted files show comparisons with the common base of the current and incoming changes to aid in resolving the conflict by making it easier to see where changes originated Rebasing
-<img src="/wp-content/uploads/commits-view-rebase.png" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/commits-view-merge.png" alt="GitLens Commits view with merge in progress">
+</figure>
 
-- any associated pull request — shows any opened or merged pull request associated with the current branch
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/commits-view-rebase.png" alt="GitLens Commits view with rebase in progress">
+</figure>
+
+- Associated pull request — displays if a pull request is linked to the current branch
 
 ***
 
 ## GitLens Inspect
 
-GitLens Inspect side bar focuses on providing contextual information and insights to what you’re actively working on. This side bar will show details for commits, stashes, pull requests, branches, autolinks, and working changes. It offers two tabs: Commit Details and Overview.
+The **GitLens Inspect** sidebar focuses on providing contextual insights related to the code you're working on. It includes two tabs: **Commit Details** and **Overview**.
 
-To open GitLens Inspect, open the Command Pallette (`command/ctrl + shift + P`) and then type: "GitLens: Show Inspect View".
+To open GitLens Inspect, launch the Command Palette (<kbd>Cmd/Ctrl + Shift + P</kbd>) and run:
+
+<kbd>GitLens: Show Inspect View</kbd>
 
 ### Commit Details
 
-The Commit tab updates as you move your cursor throughout the file with information about the commit that modified that line of code or when selecting a commit in the Commit Graph. Get quick information about the commit author, commit ID files modified in the commit, autolinks and more.
+The **Commit Details** tab updates as you move your cursor through the file or select a commit in the Commit Graph. It shows information such as commit author, ID, modified files, and autolinks.
 
-<img src="/wp-content/uploads/gl-inspect-commit-details.png" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-inspect-commit-details.png" alt="Commit details in GitLens Inspect view">
+</figure>
 
 ### Overview
 
-The Overview tab allows you to view your work-in-progress changes any time without losing context on your current selected change. The tab includes the ability to stage and unstage changes, open files to view changes, see pull requests, [suggest changes or see Code Suggestions](/gitlens/gitlens-features/#code-suggest-preview) for an open pull request and open the changes in the Commit Graph and SCM view.
+The **Overview** tab helps you stage or unstage changes, open files to view modifications, and access associated pull requests. You can also [suggest changes or view Code Suggestions](/gitlens/gitlens-features/#code-suggest-preview) when working on a pull request.
 
-<img src="/wp-content/uploads/gl-inspect-overview.png" class="help-center-img img-bordered">
-
-***
-
-## Repositories view
-
-<img src="/wp-content/uploads/repositories-view.png" class="help-center-img img-bordered">
-
-A hidden by default, [customizable](/gitlens/settings/#repositories-view-settings) view to visualize, explore, and manage Git repositories
-
-The _Repositories_ view lists opened Git repositories, and additionally provides:
-
-- a toggle to automatically refresh the repository on changes
-- a toggle to change the file layout: list, tree, auto
--  an icon overlay indicator to show the current branch's upstream status (if available)
-    - _No dot_ — no changes or the branch is unpushlished
-    - _Green dot_ — has changes unpushed (ahead)
-    - _Red dot_ — has changes unpulled (behind)
-    - _Yellow dot_ — both unpushed and unpulled changes
-- a branch comparison tool **(Compare <current branch> with <branch, tag, or ref>)** — [optionally](/gitlens/gitlens-settings/#repositories-view-settings) shows a comparison of the current branch (or working tree) to a user-selected reference
-    - **Behind** — lists the commits that are missing from the current branch (i.e. behind) but exist in the selected reference
-        - **Number of files changed** — lists all of the files changed between the compared references
-    - **Ahead** — lists the commits that the current branch has (i.e. ahead) but are missing in the selected reference
-        - **# files changed** — lists all of the files changed between the compared references
-- **files changed** — [optionally](/gitlens/gitlens-settings/#repositories-view-settings) lists all of the files changed in the working tree
-- the current branch status — [optionally](/gitlens/gitlens-settings/#repositories-view-settings) shows the upstream status of the current branch
-    - **Publish \<current branch\>** to remote — shown when the current branch has not been published to a remote
-    - **Up to date with \<remote\>** — shown when the current branch is up to date with the upstream remote
-    - **Changes to pull from \<remote\>** — lists all of the unpulled commits and all of the files changed in them, when the current branch has commits that are waiting to be pulled from the upstream remote
-    - **Changes to push to \<remote\>** — lists of all the unpublished commits and all of the files changed in them, when the current branch has commits that waiting to be pushed to the upstream remote
-    - **Merging into \<branch\>** or **Resolve conflicts before merging into \<branch\>** — lists any conflicted files. Conflicted files show comparisons with the common base of the current and incoming changes to aid in resolving the conflict by making it easier to see where changes originated
-    - **Rebasing \<branch\>** or **Resolve conflicts to continue rebasing \<branch\>** — shows the number of rebase steps left, the commit the rebase is paused at, and lists any conflicted files. Conflicted files show comparisons with the common base of the current and incoming changes to aid in resolving the conflict by making it easier to see where changes originated
-- any associated pull request — optionally shows any opened or merged pull request associated with the current branch
-- **Commits** — [optionally](/gitlens/gitlens-settings/#repositories-view-settings) shows the current branch commits, similar to the Commits view
-- **Branches** — [optionally](/gitlens/gitlens-settings/#repositories-view-settings) shows the local branches, similar to the Branches view
-- **Remotes** — [optionally](/gitlens/gitlens-settings/#repositories-view-settings) shows the remotes and remote branches, similar to the Remotes view
-- **Stashes** — [optionally](/gitlens/gitlens-settings/#repositories-view-settings) shows the stashes, similar to the Stashes view
-- **Tags** — [optionally](/gitlens/gitlens-settings/#repositories-view-settings) shows the tags, similar to the Tags view
-- **Contributors** — [optionally](/gitlens/gitlens-settings/#repositories-view-settings) shows the contributors, similar to the Contributors view
-- **Incoming Activity** (experimental) — [optionally](/gitlens/gitlens-settings/#repositories-view-settings) shows any incoming activity, which lists the command, branch (if available), and date of recent incoming activity (merges and pulls) to your local repository
-
-***
-
-## File History view
-
-<img src="/wp-content/uploads/file-history-view.png" class="help-center-img img-bordered">
-
-A [customizable](/gitlens/settings/#file-history-view-settings) view to visualize, navigate, and explore the revision history of the current file or just the selected lines of the current file
-
-The file history view lists all of the commits that changed the current file on the current branch, and additionally provides:
-
-- a toggle to pin (pause) the automatic tracking of the current editor
-- a toggle to switch between file and line history, i.e. show all commits of the current file, or just the selected lines of the current file
-- the ability to change the current base branch or reference when computing the file or line history
-- (file history only) a toggle to follow renames across the current file
-- (file history only) a toggle to show commits from all branches rather than just from the current base branch or reference
-- merge conflict status when applicable
-    - **Merge Changes** — show comparisons with the common base of the current and incoming changes to aid in resolving the conflict by making it easier to see where changes originated
-
-<img src="/wp-content/uploads/file-history-view-merge-conflict.png" class="help-center-img img-bordered">
-
-***
-
-## Line History view
-
-<img src="/wp-content/uploads/line-history-view.png" class="help-center-img img-bordered">
-
-A hidden by default, [customizable](/gitlens/settings/#line-history-view-settings) view to visualize, navigate, and explore the revision history of the selected lines of the current file
-
-The line history view lists all of the commits that changed the selected lines of the current file on the current branch, and additionally provides:
-
-- a toggle to pin (pause) the automatic tracking of the current editor
-- the ability to change the current base branch or reference when computing the line history
-- merge conflict status when applicable
-    - **Merge Changes** — show comparisons with the common base of the current and incoming changes to aid in resolving the conflict by making it easier to see where changes originated
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-inspect-overview.png" alt="GitLens Inspect view with code overview and pull request context">
+</figure>
 
 
 ***
 
-## Branches view
+## Repositories View
 
-<img src="/wp-content/uploads/branches-view.png" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/repositories-view.png" alt="GitLens Repositories view">
+</figure>
 
-A [customizable](/gitlens/settings/#branches-view-settings)  view to visualize, explore, and manage Git branches
+A hidden by default, [customizable](/gitlens/settings/#repositories-view-settings) view to visualize, explore, and manage Git repositories.
 
-The _Branches_ view lists all of the local branches, and additionally provides:
+The **Repositories** view lists all open Git repositories. It includes:
 
-- a toggle to change the branch layout: list or tree
-- a toggle to change the file layout: list, tree, auto
-- an icon overlay indicator to show the branch's upstream status (if available)
-    - _No dot_ — no changes or the branch is unpushlished
-    - _Green dot_ — has changes unpushed (ahead)
-    - _Red dot_ — has changes unpulled (behind)
-    - _Yellow dot_ — both unpushed and unpulled changes
-- status indicators (decorations), on the right, and themeable colorizations
-    - `✓` — indicates that the branch is the current branch
-    - `▲` + green colorization — indicates that the branch has unpushed changes (ahead)
-    - `▼` + red colorization — indicates that the branch has unpulled changes (behind)
-    - `▼▲` + yellow colorization — indicates that the branch has diverged from its upstream; meaning it has both unpulled and unpushed changes
-    - `▲+` + green colorization — indicates that the branch hasn't yet been published to an upstream remote
-    - `!` + dark red colorization — indicates that the branch has a missing upstream (e.g. the upstream branch was deleted)
-- a branch comparison tool **(Compare <branch> with <branch, tag, or ref>)** — [optionally](/gitlens/settings/#branches-view-settings) shows a comparison of the branch to a user-selected reference
-    - **Behind** — lists the commits that are missing from the branch (i.e. behind) but exist in the selected reference
-        - **Number of files changed** — lists all of the files changed in the behind commits
-    - **Ahead** — lists the commits that the branch has (i.e. ahead) but are missing in the selected reference
-        - **number of files changed** — lists all of the files changed in the ahead commits
-    - **Number of files changed** — lists all of the files changed between the compared references
-- the branch status — shows the upstream status of the branch
-    - **Publish \<branch\> to \<remote\>** — shown when the current branch has not been published to a remote
-    - **Changes to push to \<remote\>** — lists of all the files changed in the unpublished commits when the branch has (unpublished) commits that waiting to be pushed to the upstream remote
-    - **Changes to pull from \<remote\>** — lists all of the commits waiting to be pulled when the branch has commits that are waiting to be pulled from the upstream remote
-- any associated pull request — shows any pull request associated with the branch
+- A toggle to auto-refresh repository changes
+- A toggle to switch file layout: list, tree, or auto
+- Upstream status indicators:
+  - No dot — branch unpublished or no changes
+  - Green dot — commits ahead of upstream
+  - Red dot — commits behind upstream
+  - Yellow dot — ahead and behind
+- A branch comparison tool — compare the current branch with a selected branch, tag, or ref:
+  - **Behind** — commits missing from current branch
+  - **Ahead** — commits present in current branch only
+- Optionally show:
+  - Changed files in the working tree
+  - Current branch status with upstream (e.g., publish, up to date, changes to pull or push)
+  - Associated pull request
+  - Commit history (like the Commits view)
+  - Local branches (like the Branches view)
+  - Remotes and branches (like the Remotes view)
+  - Stashes, tags, and contributors
+  - **Incoming Activity** (experimental) — recent merge and pull events
 
 ***
 
-## Remotes view
 
-<img src="/wp-content/uploads/remotes-view.png" class="help-center-img img-bordered">
+## File History View
 
-A [customizable](/gitlens/settings/#remotes-view-settings) view to visualize, explore, and manage Git remotes and remote branches
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/file-history-view.png" alt="GitLens File History view">
+</figure>
 
-The _Remotes_ view lists all of the remotes and their remote branches, and additionally provides:
+A [customizable](/gitlens/settings/#file-history-view-settings) view to visualize, navigate, and explore the revision history of the current file or selected lines.
 
-- a toggle to change the branch layout: list or tree
-- a toggle to change the file layout: list, tree, auto
-- a toggle to connect to a supported remote providers to enable a rich integration with pull requests, issues, avatars, and more
+The **File History** view lists all commits that modified the current file on the active branch. It includes:
 
-***
+- A toggle to pin (pause) automatic tracking of the current editor
+- A toggle to switch between file and line history
+- The ability to change the base branch or reference for history
+- (File history only) A toggle to follow renames
+- (File history only) A toggle to show commits from all branches
+- Merge conflict status (if applicable):
+  - **Merge Changes** — compare base and incoming changes to aid in resolving conflicts
 
-## Stashes view
-
-<img src="/wp-content/uploads/stashes-view.png" class="help-center-img img-bordered">
-
-A [customizable](/gitlens/settings/#stashes-view-settings)  view to visualize, explore, and manage Git stashes
-
-The _Stashes_ view lists all of the stashes, and additionally provides:
-
-- a toggle to change the file layout: list, tree, auto
-
-***
-
-## Tags view
-
-<img src="/wp-content/uploads/tags-view.png" class="help-center-img img-bordered">
-
-A [customizable](/gitlens/settings/#tags-view-settings) view to visualize, explore, and manage Git tags
-
-The _Tags_ view lists all of the tags, and additionally provides:
-
-- a toggle to change the tag layout: list or tree
-- a toggle to change the file layout: list, tree, auto
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/file-history-view-merge-conflict.png" alt="File History view showing a merge conflict">
+</figure>
 
 ***
 
-## Launchpad view `PRO`
+## Line History View
 
-The Launchpad view is a view that offers the ability to always have the [Launchpad](/gitlens/gitlens-features/#launchpad) open in the side bar. This allows you to view pull request details at a glance in a tree format and take action. You can enable this experimental feature either by running the _Show Launchpad View_ command or setting `gitlens.views.launchpad.enabled` to `true` in your settings file.
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/line-history-view.png" alt="GitLens Line History view">
+</figure>
 
-<img src="/wp-content/uploads/gl-launchpad-view-experimental.png" class="help-center-img img-bordered">
+A hidden by default, [customizable](/gitlens/settings/#line-history-view-settings) view to visualize, navigate, and explore the revision history of the selected lines of the current file.
+
+The **Line History** view lists all commits that modified the selected lines. It provides:
+
+- A toggle to pin (pause) automatic tracking of the current editor
+- The ability to change the base branch or reference
+- Merge conflict status (if applicable):
+  - **Merge Changes** — compare base and incoming changes to aid in resolving conflicts
+
+
+***
+
+## Branches View
+
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/branches-view.png" alt="GitLens Branches view">
+</figure>
+
+A [customizable](/gitlens/settings/#branches-view-settings) view to visualize, explore, and manage Git branches.
+
+The **Branches** view lists all local branches and includes:
+
+- A toggle to switch between list or tree layout
+- A toggle to change file layout: list, tree, or auto
+- Upstream status icons:
+  - No dot — branch unpublished or no changes
+  - Green dot — ahead of upstream
+  - Red dot — behind upstream
+  - Yellow dot — ahead and behind
+- Status indicators:
+  - `✓` — current branch
+  - `▲` (green) — unpushed changes
+  - `▼` (red) — unpulled changes
+  - `▼▲` (yellow) — diverged from upstream
+  - `▲+` (green) — unpublished branch
+  - `!` (dark red) — missing upstream branch
+- A comparison tool — compare a branch with another branch, tag, or ref:
+  - **Behind** — commits missing from the branch
+  - **Ahead** — commits present on the branch only
+  - **Number of files changed** — across all comparison points
+- Branch status:
+  - **Publish** — shown for unpublished branches
+  - **Changes to push** — unpublished commits
+  - **Changes to pull** — incoming commits
+- Associated pull request — shown when linked to a branch
+
+***
+
+## Remotes View
+
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/remotes-view.png" alt="GitLens Remotes view">
+</figure>
+
+A [customizable](/gitlens/settings/#remotes-view-settings) view to visualize, explore, and manage Git remotes and remote branches.
+
+The **Remotes** view lists all remotes and their remote branches. It includes:
+
+- A toggle to switch between list or tree layout for branches
+- A toggle to change file layout: list, tree, or auto
+- A toggle to connect to supported remote providers for enhanced integration with pull requests, issues, avatars, and more
+
+***
+
+## Stashes View
+
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/stashes-view.png" alt="GitLens Stashes view">
+</figure>
+
+A [customizable](/gitlens/settings/#stashes-view-settings) view to visualize, explore, and manage Git stashes.
+
+The **Stashes** view lists all stashes and includes:
+
+- A toggle to change file layout: list, tree, or auto
+
+***
+
+## Tags View
+
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/tags-view.png" alt="GitLens Tags view">
+</figure>
+
+A [customizable](/gitlens/settings/#tags-view-settings) view to visualize, explore, and manage Git tags.
+
+The **Tags** view lists all tags and includes:
+
+- A toggle to switch tag layout: list or tree
+- A toggle to change file layout: list, tree, or auto
+
+***
+
+## Launchpad View `PRO`
+
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-launchpad-view-experimental.png" alt="GitLens Launchpad view (experimental)">
+</figure>
+
+The **Launchpad** view provides an always-visible panel for pull request activity. You can view pull request details in a tree format and take action directly from the sidebar.
+
+To enable this experimental feature, either run the _Show Launchpad View_ command or set `gitlens.views.launchpad.enabled` to `true` in your settings file.
+
+***
 
 ## Workspaces
 
-Workspaces are a convenient way to group and manage multiple repositories, making them easily accessible from anywhere. Whether you're working individually or collaborating with a team, Workspaces provide a seamless way to manage your projects. A Workspace can be made up of local repositories, those you currently have open in your VS Code window, or GitKraken Workspaces, which are repositories stored on the cloud or on GitKraken services.
+Workspaces offer a convenient way to group and manage multiple repositories for easy access. Whether working solo or as part of a team, Workspaces help streamline your development process. You can include local repositories or GitKraken Workspaces—cloud-hosted repositories or those managed through GitKraken services.
 
-Whether you're working individually or collaborating with a team, these new features are designed to help you work more efficiently and effectively.
+To access Workspaces, open the GitLens Home menu and find them in the lower-left panel. Alternatively, search "Workspaces" via the Command Palette.
 
-To access Workspaces, simply open the GitLens Home menu and you will find them in the panel located at the bottom left. Alternatively, you can access them by performing a search in the command palette.
+> Note: Using cloud Workspaces requires a GitKraken account. Sharing cloud Workspaces requires a trial or paid subscription.
 
-Please note that while using cloud workspaces requires a GitKraken account, shared cloud workspaces require a trial or subscription.
-
-<img src="/wp-content/uploads/gl-workspaces-sidebar.png" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-workspaces-sidebar.png" alt="GitLens Workspaces in the sidebar">
+</figure>
 
 ### Creating a Workspace
 
-To create a workspace, tap the '+' button next to GitKraken Workspaces, provide a name and a description, and connect a provider if you wish.
+Click the **+** icon next to GitKraken Workspaces to create a new Workspace. Enter a name and description, and optionally connect a provider.
 
-<img src="/wp-content/uploads/gl-create-workspace.png" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-create-workspace.png" alt="Create a GitLens Workspace">
+</figure>
 
 ### Adding Repositories
 
-You can add repositories to a workspace by tapping the '+' button under the Workspace tab. And if you want to keep your Workspaces and their repositories up-to-date, simply tap the Refresh icon.
+Add repositories to your Workspace using the **+** icon under the Workspace tab. Click the Refresh icon to sync updates.
 
-<img src="/wp-content/uploads/gl-add-repo-to-workspace.png" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-add-repo-to-workspace.png" alt="Add a repository to a Workspace">
+</figure>
 
 ### Locating Repositories
 
-To locate the disk location of the repositories within the Cloud Workspace, select the 'Locate Repositories' (pin icon) next to the repository name. If you have a folder set up for a Workspace with multiple repositories on your disk, you can select the option and choose the parent folder. GitLens will then find all the repositories within that parent folder.
+To find a repository’s location on disk, click the **Locate Repositories** (pin icon). Select a parent folder, and GitLens will scan it for repositories.
 
-<img src="/wp-content/uploads/gl-locate-repo-in-workspace.png" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-locate-repo-in-workspace.png" alt="Locate a repo in a Workspace">
+</figure>
 
 ### Opening Repositories
 
-To open a repository from a Workspace tap the 'Open Repository in New Window' icon.
+To open a repository, click the **Open Repository in New Window** icon. 
 
-_Pro Tip: If you prefer to open the Workspace in your current window, hold down the ALT/OPTION key on a Mac and click 'Open Repo'._
+> Pro Tip: Hold <kbd>Alt/Option</kbd> while clicking to open in the current window.
 
-<img src="/wp-content/uploads/gl-open-as-vscode-workspace.png" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-open-as-vscode-workspace.png" alt="Open Workspace repository in VS Code">
+</figure>
 
 ### Removing Repositories
 
-To remove a repository from a Workspace, you can do so by right-clicking to open the context menu on the repository you wish to remove and then selecting 'remove repository from Workspace'.
+Right-click a repository and choose **Remove repository from Workspace** to remove it.
 
-<img src="/wp-content/uploads/gl-remove-repo-from-wrokspace.png" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-remove-repo-from-wrokspace.png" alt="Remove repository from Workspace">
+</figure>
 
 ### Converting to Cloud Workspaces
 
-To convert your local VSCode workspace into a GitKraken Workspace, press the 'Convert to Cloud Workspace' icon, provide a name and a description, and your workspace will be stored in the cloud for your GitKraken user account. This means that your Cloud Workspace will now appear in any of your GitKraken shared services, such as GitKraken Desktop, GitLens, and the GitKraken CLI.
+To convert a local Workspace, click **Convert to Cloud Workspace**, add a name and description, and save. Your Workspace will be available across GitKraken tools.
 
-<img src="/wp-content/uploads/gl-convert-workspace-to-cloud.png" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-convert-workspace-to-cloud.png" alt="Convert local Workspace to GitKraken Cloud">
+</figure>
 
-### Understanding Workspace indicators and colors
+### Workspace Indicators and Colors
 
-Workspaces also include visual indicators to help you understand their status. For example, a green Workspace with an 'O' symbol indicates that it is open in your current window.
+Workspace status indicators use symbols and colors, such as a green **O** for the currently open Workspace.
 
-<img src="/wp-content/uploads/gl-workspace-indicators.png" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-workspace-indicators.png" alt="GitLens Workspace status indicators">
+</figure>
 
-### Workspace linking
+### Workspace Linking
 
-A VS Code workspace can be created from a GitKraken Workspace to link them.
+You can link a GitKraken Workspace to a VS Code workspace.
 
-<img src="/wp-content/uploads/gl-create-vs-workspace-from-gl.png" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-create-vs-workspace-from-gl.png" alt="Create a VS Code Workspace from GitKraken">
+</figure>
 
-You can open a linked VS Code workspace from its cloud workspace using the new `Open VS Code Workspace in New Window` option (hold alt to open in the current window).
+Linked VS Code workspaces can be opened from their cloud counterpart using **Open VS Code Workspace in New Window** (hold <kbd>Alt</kbd> to open in the current window).
 
-When repositories are added to a GitKraken Cloud workspace, you can automatically add those repositories to its linked VS Code workspace when that workspace is opened. You can choose to automatically add the repositories, be prompted to add them, or disable auto-adding repositories altogether for that workspace. This setting is chosen when creating the VS Code workspace, but can be changed at any time using the new `Change Linked Workspace Auto-Add Behavior` command on the `Current Window` item or its linked workspace in the _Workspaces_ view.
+When you add repositories to a GitKraken Workspace, they can be auto-added to its linked VS Code workspace. You choose the auto-add behavior when creating the workspace and can modify it later via the **Change Linked Workspace Auto-Add Behavior** command.
 
-<img src="/wp-content/uploads/gl-link-repositories-in-workspaces.png" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/gl-link-repositories-in-workspaces.png" alt="Link repositories to VS Code workspace">
+</figure>
 
-You can also manually add repositories to the VS Code workspace at any time using the new `Add Repositories from Linked Workspace` command.
+To manually add repositories, use the **Add Repositories from Linked Workspace** command.
 
-***
-
-## Worktrees view
-
-<img src="/wp-content/uploads/worktrees-view.png" class="help-center-img img-bordered">
-
-A [customizable](gitlens/gitlens-settings/#worktrees-view-settings) view to create, view, and work with <a href="https://www.gitkraken.com/learn/git/git-worktree" target="_blank">Worktrees</a>. Worktrees allow multiple branches to be checked-out at once on the same repository. This makes it easier to develop on, or test multiple branches, by minimizing the context switching between branches.
-
-***
-
-## Contributors view
-
-<img src="/wp-content/uploads/contributors-view.png" class="help-center-img img-bordered">
-
-A hidden by default, [customizable](/gitlens/settings/#contributors-view-settings) view to visualize, navigate, and explore contributors
-
-The Contributors view lists all of the contributors, and additionally provides:
-
-- a toggle to change the file layout: list, tree, auto
 
 ***
 
-## Search & Compare view
+## Worktrees View
 
-<img src="/wp-content/uploads/search-and-compare-view.png" class="help-center-img img-bordered">
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/worktrees-view.png" alt="GitLens Worktrees view">
+</figure>
 
-A hidden by default, [customizable](/gitlens/settings/#search-and-compare-view-settings) view to search and explore commit histories by message, author, files, id, etc, or visualize comparisons between branches, tags, commits, and more
+A [customizable](gitlens/gitlens-settings/#worktrees-view-settings) view to create, view, and manage [Git worktrees](https://www.gitkraken.com/learn/git/git-worktree). Worktrees allow you to check out multiple branches at once within the same repository—useful for parallel development or testing workflows without switching branches.
 
-The _Search & Compare_ view lists pinnable (saved) results for searching commit histories or for comparison operations, and additionally provides,
+***
 
-- a toggle to keep previous results when new results are added
-- a toggle to change the file layout: list, tree, auto
-- pinnable search — lists all of the commits that match the search query
-    - Search results can be provided by the following commands
-        - _Search Commits_ command (`gitlens.showCommitSearch`) can search
-            - by message — use `<message>` to find commits with messages that match `<message>` — See Git docs
-            - or, by author — use `@<pattern>` to find commits with authors that match `<pattern>` — See Git docs
-            - or, by commit SHA — use `#<sha>` to find a commit with SHA of `<sha>` — See Git docs
-            - or, by files — use `:<path/glob>` to find commits with file names that match `<path/glob>` — See Git docs
-            - or, by changes — use `~<pattern>` to find commits with differences whose patch text contains added/removed lines that match `<pattern>` — See Git docs
-        - _Show File History_ command (`gitlens.showQuickFileHistory`)
-        - _Show Commit_ command (`gitlens.showQuickCommitDetails`)
-- pinnable comparison — shows a comparison of the two user-selected references
-    - **Behind** — lists the commits that are missing from the branch (i.e. behind) but exist in the selected reference
-        - **Number of files changed** — lists all of the files changed in the behind commits
-    - **Ahead** — lists the commits that the branch has (i.e. ahead) but are missing in the selected reference
-        - **Number of files changed** — lists all of the files changed in the ahead commits
-    - **Number of files changed** — lists all of the files changed between the compared references
-    - Comparision results can be provided by the following commands
-        - _Compare with Upstream_ command (`gitlens.views.compareWithUpstream`)
-        - _Compare Working Tree to Here_ command (`gitlens.views.compareWithWorking`)
-        - _Compare with HEAD_ command (`gitlens.views.compareWithHead`)
-        - _Compare with Selected_ command (`gitlens.views.compareWithSelected`)
-        - _Compare Ancestry with Working Tree_ command (`gitlens.views.compareAncestryWithWorking`)
-- a checkbox next to files to allow tracking review progress
+## Contributors View
+
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/contributors-view.png" alt="GitLens Contributors view">
+</figure>
+
+A hidden by default, [customizable](/gitlens/settings/#contributors-view-settings) view to explore repository contributors.
+
+The **Contributors** view lists all contributors and includes:
+
+- A toggle to change file layout: list, tree, or auto
+
+***
+
+## Search & Compare View
+
+<figure class="help-center-img img-bordered">
+  <img src="/wp-content/uploads/search-and-compare-view.png" alt="GitLens Search and Compare view">
+</figure>
+
+A hidden by default, [customizable](/gitlens/settings/#search-and-compare-view-settings) view to search commit history or compare branches, tags, commits, and more.
+
+The **Search & Compare** view displays pinnable results from search or comparison operations. It includes:
+
+- A toggle to retain previous results
+- A toggle to change file layout: list, tree, or auto
+
+### Pinnable Search
+
+Search commits by message, author, file, ID, or patch using:
+
+- **Search Commits** (`gitlens.showCommitSearch`):
+  - `<message>` — message match
+  - `@<pattern>` — author match
+  - `#<sha>` — commit SHA
+  - `:<path/glob>` — filename pattern
+  - `~<pattern>` — patch content match
+- **Show File History** (`gitlens.showQuickFileHistory`)
+- **Show Commit** (`gitlens.showQuickCommitDetails`)
+
+### Pinnable Comparison
+
+Compare any two references:
+
+- **Behind** — commits missing from the target branch
+- **Ahead** — commits unique to the target branch
+- **Number of files changed** — file diffs between the two references
+
+Comparison commands include:
+
+- `gitlens.views.compareWithUpstream`
+- `gitlens.views.compareWithWorking`
+- `gitlens.views.compareWithHead`
+- `gitlens.views.compareWithSelected`
+- `gitlens.views.compareAncestryWithWorking`
+
+You can use checkboxes next to files to track review progress.


### PR DESCRIPTION
Hey y'all. This PR adds a new documentation page touches up the GitLens sidebars and their features, including the Inspect, GitLens, and Source Control sidebars.

I used Purple GPT to apply Google Technical Writing standards, and I checked against production as I went along. Could still use a hand making sure we're saying the same thing but better
