### PR TITLE
docs: GitLens v17.11.0 validation — add Git Submodules section

### DIFF
--- a/gitlens/gitlens-features.md
+++ b/gitlens/gitlens-features.md
@@ -1080,6 +1080,14 @@ Adds a [customizable](/gitlens/settings/#git-command-palette-settings) Git Comma
 
 ---
 
+## Git Submodules
+
+GitLens provides basic support for Git submodules, automatically discovering and tracking submodules within your repositories. Submodules are distinguished from regular repositories and worktrees in GitLens views with dedicated icons and tooltips, making it easy to identify which repositories are submodules at a glance.
+
+When viewing changes to a submodule, GitLens displays the submodule commit reference in the standard Git format, allowing you to see which commit a submodule points to and how it has changed.
+
+---
+
 ## Interactive Rebase Editor
 
 <figure>


### PR DESCRIPTION
## GitLens v17.11.0 docs validation (Aug 21)

**Range:** `v17.10.0..v17.11.0` (123 commits, 429 changed files)

### Findings summary

| # | Surface | Verdict |
|---|---------|---------|
| 1 | logging-rewrite | nothing — FAQ and settings already accurate |
| 2 | welcome-page-rewrite | nothing — internal restructure, no docs impact |
| 3 | stash-unstaged-confirm | nothing — UX-only change, no docs surface |
| 4 | ai-model-updates | nothing — model list additions, no docs needed |
| 5 | composer-previous-messages | nothing — internal context enrichment |
| 6 | git-submodule-support | **add-section** — new submodule detection in views |
| 7 | misc-refactors | nothing — internal code quality |
| 8 | showWelcomeOnInstall-setting | nothing — already documented |

### Changes in this PR

- **gitlens/gitlens-features.md**: Added "Git Submodules" section documenting submodule discovery, dedicated icons/tooltips, and commit reference display. Placed before Interactive Rebase Editor.

### Evidence

- `src/git/models/repository.ts` — `isSubmodule` (via `parentUri`), `parentUri` getter
- `src/env/node/git/localGitProvider.ts` — submodule detection in `getWorkingUri`, `superprojectPath` in `gitDirInfo`

### Gates

- Judgement gate: ✅ passed (1/1 release judged)
- Prose gate: ✅ passed (all actionable findings have prose records)
- Lint: ✅ passed on new content (28 pre-existing errors only)