### PR TITLE
docs: update GitLens docs for v17.11.0

### DIFF
--- a/gitlens/gitlens-faq.md
+++ b/gitlens/gitlens-faq.md
@@ -69,7 +69,7 @@ Or use the VS Code Command Palette:
 
 ## How do I enable debug logging?
 
-You can enable debug logging by opening the Command Palette (`ctrl+shift+p` or `command+shift+p`) and running the command `GitLens: Enable Debug Logging`.
+You can enable debug logging by opening the Command Palette (`ctrl+shift+p` or `command+shift+p`) and running the command `GitLens: Enable Debug (Trace) Logging`.
 
 <img src="/wp-content/uploads/gl-enable-debug-log.png" class="help-center-img img-bordered">
 

--- a/gitlens/gitlens-features.md
+++ b/gitlens/gitlens-features.md
@@ -1016,6 +1016,12 @@ Commit Composer is also more discoverable, with a new button on the WIP row in t
 
 ***
 
+## Git Submodule Support
+
+GitLens provides basic support for Git submodules, including automatic repository discovery and tracking of submodule repositories within your workspace. Submodules are distinguished in the sidebar and quick picks with a dedicated icon and tooltip, making it easy to identify them at a glance. Context menus are submodule-aware, so actions like external diffs and change highlighting are appropriately scoped to avoid unsupported operations on submodule entries.
+
+***
+
 ## Git Command Palette
 
 <img src="/wp-content/uploads/git-command-palette.png" class="help-center-img img-bordered">
@@ -1287,8 +1293,8 @@ GitLens provides powerful commands to improve your workflow:
 - **Open Blame Prior to Change** (`gitlens.openBlamePriorToChange`) — Show blame for the prior revision of a line.
 - **Open Changed Files** (`gitlens.openChangedFiles`) — Open all changed files in the working tree.
 - **Close Unchanged Files** (`gitlens.closeUnchangedFiles`) — Close all files without changes.
-- **Enable Debug Logging** (`gitlens.enableDebugLogging`) — Enable debug logging in the GitLens output.
-- **Disable Debug Logging** (`gitlens.disableDebugLogging`) — Disable debug logging.
+- **Enable Debug (Trace) Logging** (`gitlens.enableDebugLogging`) — Enable debug (trace) logging using VS Code's native log level controls.
+- **Disable Debug (Trace) Logging** (`gitlens.disableDebugLogging`) — Disable debug (trace) logging.
 - **Copy as Patch** (`gitlens.copyPatchToClipboard`) — Copy patch data from views, changes, or stashes.
 - **Apply Copied Patch** (`gitlens.applyPatchFromClipboard`) — Apply a patch from clipboard contents.
 

--- a/gitlens/gitlens-settings.md
+++ b/gitlens/gitlens-settings.md
@@ -1436,7 +1436,11 @@ Another custom example:<br>
 <code>anthropic:claude-3-5-sonnet-latest</code><br>
 <code>anthropic:claude-3-sonnet-20240229</code><br>
 <code>anthropic:claude-3-5-sonnet-20240620</code><br>
-<code>anthropic:claude-3-5-sonnet-20241022</code>
+<code>anthropic:claude-3-5-sonnet-20241022</code><br>
+<code>anthropic:claude-sonnet-4-6</code><br>
+<code>anthropic:claude-opus-4-6</code><br>
+<code>google:gemini-3.1-pro-preview</code><br>
+<code>google:gemini-3.1-flash-lite-preview</code>
 </td>
 </tr>
 <tr>
@@ -1547,11 +1551,11 @@ Another custom example:<br>
 </tr>
 <tr>
 <td><code>gitlens.outputLevel</code></td>
-<td>Controls the verbosity of output sent to the GitLens output channel.</td>
+<td><em>Deprecated.</em> Use the <strong>GitLens: Enable Debug (Trace) Logging</strong> and <strong>GitLens: Disable Debug (Trace) Logging</strong> commands, or the <strong>Developer: Set Log Level...</strong> command to control logging.</td>
 </tr>
 <tr>
 <td><code>gitlens.showWelcomeOnInstall</code></td>
-<td>Shows the Welcome (Quick Setup) experience on first install.</td>
+<td>Shows the Welcome view on first install.</td>
 </tr>
 <tr>
 <td><code>gitlens.showWhatsNewAfterUpgrades</code></td>


### PR DESCRIPTION
## Backfill audit: v17.10.2..v17.11.0 (1 release, 123 commits)

Mode: backfill | Range: `v17.10.2..v17.11.0`

### Findings (7 total)

| Verdict | Finding | Pages |
|---|---|---|
| update-existing | **logging-rewrite** — commands renamed to "Debug (Trace) Logging", `outputLevel` deprecated | gitlens-faq.md, gitlens-features.md, gitlens-settings.md |
| update-existing | **welcome-view-refactor** — standalone Welcome view, not Quick Setup overlay | gitlens-settings.md |
| update-existing | **ai-model-additions** — Claude Sonnet 4.6, Opus 4.6, Gemini 3.1 Pro/Flash-Lite | gitlens-settings.md |
| add-section | **submodule-support** — new feature, zero prior coverage | gitlens-features.md |
| nothing | commit-composer-recompose-context — internal AI prompt improvement |
| nothing | stash-unstaged-fix — bug fix, no docs surface |
| nothing | internal-improvements — log scope refactor, LRU cache, async FS, rebase parser, etc. |

### Prose edits (6 across 3 pages)

- **gitlens-faq.md:72** — command name updated to "Enable Debug (Trace) Logging"
- **gitlens-features.md:1290-1291** — command names and descriptions updated
- **gitlens-features.md** — new "Git Submodule Support" section added
- **gitlens-settings.md:1549-1550** — `outputLevel` marked deprecated
- **gitlens-settings.md:1554** — `showWelcomeOnInstall` description updated
- **gitlens-settings.md:1439+** — four new AI model values added

### Deferred

- **15 images** without specs (pre-existing, not introduced by v17.11.0)
- **10 images** without alt text on actionable pages (pre-existing)
- **Capture** could not run — no VS Code/Xvfb in this environment
- All lint errors on edited pages are pre-existing (missing alt attributes, heading structure)